### PR TITLE
put back color in apr breakdown

### DIFF
--- a/components/apr-tooltip/AprTooltip.tsx
+++ b/components/apr-tooltip/AprTooltip.tsx
@@ -82,7 +82,7 @@ function AprTooltip({ data, textProps, onlySparkles, placement, aprLabel, sparkl
                                             mt={subItemIndex === 0 ? '-0.3rem' : '-1.7rem'}
                                             bgColor="gray.100"
                                         />
-                                        <Box h="1px" w="0.75rem" mr="0.25rem" ml="-0.25rem" />
+                                        <Box h="1px" w="0.75rem" mr="0.25rem" ml="-0.25rem" bgColor="gray.100" />
                                         <Flex>
                                             {formatApr(subItem.apr)} <AprText>{subItem.title}</AprText>
                                         </Flex>


### PR DESCRIPTION
I merged out the apr breakdown color myself. Putting it back again...

![image](https://user-images.githubusercontent.com/20125808/180230163-60a6a242-f4e1-4d2b-b235-4e4c62299141.png)
