### PR TITLE
add slippage to invest / withdraw preview

### DIFF
--- a/modules/pool/invest/components/PoolInvestPreview.tsx
+++ b/modules/pool/invest/components/PoolInvestPreview.tsx
@@ -7,6 +7,7 @@ import { useGetTokens } from '~/lib/global/useToken';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
 import { PoolInvestSummary } from '~/modules/pool/invest/components/PoolInvestSummary';
 import { PoolInvestActions } from '~/modules/pool/invest/components/PoolInvestActions';
+import { PoolInvestSettings } from '~/modules/pool/invest/components/PoolInvestSettings';
 import { CardRow } from '~/components/card/CardRow';
 
 interface Props {
@@ -43,6 +44,7 @@ export function PoolInvestPreview({ onInvestComplete, onClose }: Props) {
                 })}
             </BeetsBox>
             <PoolInvestSummary mt="6" />
+            <PoolInvestSettings mt="8" />
             <PoolInvestActions onInvestComplete={onInvestComplete} onClose={onClose} />
         </Box>
     );

--- a/modules/pool/withdraw/components/PoolWithdrawPreview.tsx
+++ b/modules/pool/withdraw/components/PoolWithdrawPreview.tsx
@@ -15,8 +15,7 @@ import { CardRow } from '~/components/card/CardRow';
 import { FadeInBox } from '~/components/animation/FadeInBox';
 import { TransactionSubmittedContent } from '~/components/transaction/TransactionSubmittedContent';
 import { sum } from 'lodash';
-import { InfoButton } from '~/components/info-button/InfoButton';
-import { SlippageTextLinkMenu } from '~/components/slippage/SlippageTextLinkMenu';
+import { PoolWithdrawSettings } from '~/modules/pool/withdraw/components/PoolWithdrawSettings';
 
 interface Props {
     onWithdrawComplete(): void;
@@ -55,7 +54,8 @@ export function PoolWithdrawPreview({ onWithdrawComplete }: Props) {
                     );
                 })}
             </BeetsBox>
-            <PoolWithdrawSummary mt="6" mb="8" />
+            <PoolWithdrawSummary mt="6" />
+            <PoolWithdrawSettings mt="6" mb="8" />
             <FadeInBox isVisible={exitPoolQuery.isConfirmed || exitPoolQuery.isPending || exitPoolQuery.isFailed}>
                 <Text fontSize="lg" fontWeight="semibold" mt="4" mb="2">
                     Transaction details

--- a/modules/pool/withdraw/components/PoolWithdrawProportional.tsx
+++ b/modules/pool/withdraw/components/PoolWithdrawProportional.tsx
@@ -120,7 +120,7 @@ export function PoolWithdrawProportional({ onShowPreview, ...rest }: Props) {
             </BeetsBox>
 
             <PoolWithdrawSummary mt="6" />
-            <PoolWithdrawSettings mt="6" />
+            <PoolWithdrawSettings mt="8" />
             <Button variant="primary" isFullWidth mt="8" onClick={onShowPreview}>
                 Preview
             </Button>

--- a/modules/pool/withdraw/components/PoolWithdrawSingleAsset.tsx
+++ b/modules/pool/withdraw/components/PoolWithdrawSingleAsset.tsx
@@ -63,7 +63,7 @@ export function PoolWithdrawSingleAsset({ onShowPreview, ...rest }: Props) {
                 setSelectedTokenOption={setSingleAssetWithdraw}
             />
             <PoolWithdrawSummary mt="6" />
-            <PoolWithdrawSettings mt="6" />
+            <PoolWithdrawSettings mt="8" />
             <Collapse in={hasHighPriceImpact} animateOpacity>
                 <Alert status="error" borderRadius="md" mt="4">
                     <Checkbox


### PR DESCRIPTION
Added settings for slippage to invest and withdraw preview. Currently the invest only has slippage enabled, no zap or other settings. When zap is enabled this will be visible on preview.

Changed margin on withdraw single and proportional to match invest margin

[combined invest and withdraw in one PR because they seemed like small changes]