### PR TITLE
Fixed pool detail transaction list non-themed hover color

### DIFF
--- a/modules/pool/detail/components/transactions/PoolTransactionRow.tsx
+++ b/modules/pool/detail/components/transactions/PoolTransactionRow.tsx
@@ -156,7 +156,7 @@ export default function PoolTransactionItem({ transaction, ...rest }: Props) {
                 lg: `"action details value time"`,
             }}
             bgColor="rgba(255,255,255,0.05)"
-            _hover={{ bg: '#100C3A' }}
+            _hover={{ bg: 'beets.base.800' }}
         >
             <Flex align={flexAlign}>
                 <GridItem area="action">


### PR DESCRIPTION
on pool details page, when viewing transactions or swaps. the hover color is hard coded

![image](https://user-images.githubusercontent.com/99622829/183462113-25e586ef-372c-4446-a061-c5cc4e149b9b.png)

update to pull from theme file.

![image](https://user-images.githubusercontent.com/99622829/183462318-8984ad2d-2501-46cd-9c6c-16b091321afe.png)
