### PR TITLE
Include Settings on the Invest and Withdraw Preview

### DIFF
--- a/modules/pool/invest/components/PoolInvestPreview.tsx
+++ b/modules/pool/invest/components/PoolInvestPreview.tsx
@@ -7,6 +7,7 @@ import { useGetTokens } from '~/lib/global/useToken';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
 import { PoolInvestSummary } from '~/modules/pool/invest/components/PoolInvestSummary';
 import { PoolInvestActions } from '~/modules/pool/invest/components/PoolInvestActions';
+import { PoolInvestSettings } from '~/modules/pool/invest/components/PoolInvestSettings';
 import { CardRow } from '~/components/card/CardRow';
 
 interface Props {
@@ -43,6 +44,7 @@ export function PoolInvestPreview({ onInvestComplete, onClose }: Props) {
                 })}
             </BeetsBox>
             <PoolInvestSummary mt="6" />
+            <PoolInvestSettings mt="6" />
             <PoolInvestActions onInvestComplete={onInvestComplete} onClose={onClose} />
         </Box>
     );

--- a/modules/pool/withdraw/components/PoolWithdrawPreview.tsx
+++ b/modules/pool/withdraw/components/PoolWithdrawPreview.tsx
@@ -16,6 +16,7 @@ import { TransactionSubmittedContent } from '~/components/transaction/Transactio
 import { sum } from 'lodash';
 import { usePool } from '~/modules/pool/lib/usePool';
 import { usePoolUserBptBalance } from '~/modules/pool/lib/usePoolUserBptBalance';
+import { PoolWithdrawSettings } from '~/modules/pool/withdraw/components/PoolWithdrawSettings';
 
 interface Props {
     onWithdrawComplete(): void;
@@ -56,7 +57,8 @@ export function PoolWithdrawPreview({ onWithdrawComplete, onClose }: Props) {
                     );
                 })}
             </BeetsBox>
-            <PoolWithdrawSummary mt="6" mb="8" />
+            <PoolWithdrawSummary mt="6" />
+            <PoolWithdrawSettings mt="6" mb="8" />
             <FadeInBox isVisible={exitPoolQuery.isConfirmed || exitPoolQuery.isPending || exitPoolQuery.isFailed}>
                 <Text fontSize="lg" fontWeight="semibold" mt="4" mb="2">
                     Transaction details


### PR DESCRIPTION
The original request was just to put the slippage on the Preview. But it also seems convenient to see the Zap also. All of the settings are shown on the preview.