### PR TITLE
change parseUnits

### DIFF
--- a/modules/trade/lib/useBatchSwap.ts
+++ b/modules/trade/lib/useBatchSwap.ts
@@ -56,7 +56,7 @@ export function useBatchSwap() {
                         .times(slippageAddition)
                         .toFixed(0);
                 } else if (isSameAddress(tokenAddress, tokenOut) || (isEth(tokenOut) && tokenAddress === AddressZero)) {
-                    return oldBnumScaleAmount(tokenOutAmount, tokenOutDefinition.decimals).toString();
+                    return parseUnits(tokenOutAmount, tokenOutDefinition.decimals).toString();
                 }
             }
 


### PR DESCRIPTION
oldBnumScaleAmount to parseUnits. in this case using bignumber.js is not necessary. the toString() on bignumber was causing a problem because it was converting to exponential notation.