### PR TITLE
Allow user to claim rewards when rewarder is empty

### DIFF
--- a/lib/services/staking/master-chef.service.ts
+++ b/lib/services/staking/master-chef.service.ts
@@ -73,11 +73,11 @@ export class MasterChefService {
                 userAddress,
             ]);
 
-            const rewardersWithRewards = farm.rewarders || [];
+            const farmRewarders = farm.rewarders || [];
 
-            if (rewardersWithRewards.length > 0) {
+            if (farmRewarders.length > 0) {
                 //a farm will only ever have one rewarder, but the rewarder can have many tokens
-                multicaller.call(`${farm.id}.pendingRewards`, rewardersWithRewards[0].address, 'pendingTokens', [
+                multicaller.call(`${farm.id}.pendingRewards`, farmRewarders[0].address, 'pendingTokens', [
                     farm.id,
                     userAddress,
                     0,

--- a/lib/services/staking/master-chef.service.ts
+++ b/lib/services/staking/master-chef.service.ts
@@ -68,16 +68,12 @@ export class MasterChefService {
         const multicaller = new Multicaller(this.chainId, provider, mergedAbi);
 
         for (const farm of farms) {
-            if (parseFloat(farm.beetsPerBlock) > 0) {
-                multicaller.call(`${farm.id}.pendingBeets`, this.masterChefContractAddress, 'pendingBeets', [
-                    farm.id,
-                    userAddress,
-                ]);
-            }
+            multicaller.call(`${farm.id}.pendingBeets`, this.masterChefContractAddress, 'pendingBeets', [
+                farm.id,
+                userAddress,
+            ]);
 
-            const rewardersWithRewards = (farm.rewarders || []).filter(
-                (rewarder) => parseFloat(rewarder.rewardPerSecond) > 0,
-            );
+            const rewardersWithRewards = farm.rewarders || [];
 
             if (rewardersWithRewards.length > 0) {
                 //a farm will only ever have one rewarder, but the rewarder can have many tokens

--- a/modules/pool/lib/usePoolUserPendingRewards.tsx
+++ b/modules/pool/lib/usePoolUserPendingRewards.tsx
@@ -14,9 +14,12 @@ export function _usePoolUserPendingRewards() {
     const { priceForAmount } = useGetTokens();
     const farm = pool.staking?.farm;
     const gauge = pool.staking?.gauge;
-    const hasBeetsRewards = parseFloat(farm?.beetsPerBlock || '0') > 0;
 
     const { data, isLoading, ...rest } = useStakingPendingRewards(pool.staking && hasBpt ? [pool.staking] : []);
+
+    const hasBeetsRewards =
+        (data || []).filter((item) => item.address === networkConfig.beets.address && parseFloat(item.amount) > 0)
+            .length > 0;
 
     const pendingRewardsTotalUSD = sumBy(data || [], priceForAmount);
     const rewardTokens = uniq([
@@ -27,7 +30,6 @@ export function _usePoolUserPendingRewards() {
 
     const pendingRewards: TokenAmountHumanReadable[] = rewardTokens.map((rewardToken) => {
         const pending = (data || []).find((data) => data.address === rewardToken);
-
         return pending || { address: rewardToken, amount: '0' };
     });
 


### PR DESCRIPTION
Removed check for active rewards (both beets and other tokens) when getting user rewards from farms.


