### PR TITLE
Fixed: Pool list text search box clears after navigation search but still set

### DIFF
--- a/modules/pools/components/PoolListMobileHeader.tsx
+++ b/modules/pools/components/PoolListMobileHeader.tsx
@@ -15,11 +15,20 @@ import { usePoolList } from '~/modules/pools/usePoolList';
 import { TextButtonPopupMenu } from '~/components/popup-menu/TextButtonPopupMenu';
 import { PoolListTokenMultiSelect } from '~/modules/pools/components/PoolListTokenMultiSelect';
 import { PoolListFilterMultiSelect } from '~/modules/pools/components/PoolListFilterMultiSelect';
+import { PoolListSearch } from '~/modules/pools/components/PoolListSearch';
 
 export function PoolListMobileHeader() {
     const { isOpen, onOpen, onClose } = useDisclosure();
-    const { state, setSort, refetch: refreshPoolList, showMyInvestments, setShowMyInvestments } = usePoolList();
-    const hasFiltersSelected = (state.where?.filterIn || []).length > 0 || (state.where?.tokensIn || []).length > 0;
+    const {
+        state,
+        setSort,
+        refetch: refreshPoolList,
+        showMyInvestments,
+        setShowMyInvestments,
+        searchText,
+    } = usePoolList();
+    const hasFiltersSelected =
+        (state.where?.filterIn || []).length > 0 || (state.where?.tokensIn || []).length > 0 || searchText !== '';
 
     return (
         <Flex display={{ base: 'flex', lg: 'none' }} alignItems="center" mb="4">
@@ -121,6 +130,10 @@ export function PoolListMobileHeader() {
                         <Box mb="8">
                             <Box mb="1">Categories:</Box>
                             <PoolListFilterMultiSelect />
+                        </Box>
+                        <Box mb="8">
+                            <Box mb="1">Search:</Box>
+                            <PoolListSearch />
                         </Box>
                     </ModalBody>
                 </ModalContent>

--- a/modules/pools/components/PoolListSearch.tsx
+++ b/modules/pools/components/PoolListSearch.tsx
@@ -3,17 +3,20 @@ import { Search, X } from 'react-feather';
 import { usePoolList } from '~/modules/pools/usePoolList';
 import { useBoolean } from '@chakra-ui/hooks';
 import { debounce } from 'lodash';
-import { useState } from 'react';
+import { useEffect } from 'react';
 
 export function PoolListSearch() {
     const [isSearching, { on, off }] = useBoolean();
-    const { refetch, state } = usePoolList();
-    const [searchText, setSearchText] = useState('');
+    const { refetch, state, searchText, setSearchText } = usePoolList();
 
     const submitSearch = debounce(async () => {
-        await refetch({ ...state, textSearch: searchText || null, skip: 0 });
+        await refetch({ ...state, textSearch: searchText, skip: 0 });
         off();
     }, 250);
+
+    useEffect(() => {
+        submitSearch();
+    }, [searchText]);
 
     return (
         <InputGroup size="md">
@@ -23,11 +26,7 @@ export function PoolListSearch() {
                 value={searchText}
                 onChange={(e) => {
                     setSearchText(e.target.value);
-                    if (!isSearching) {
-                        on();
-                    }
-
-                    submitSearch();
+                    if (!isSearching) on();
                 }}
             />
             <InputRightElement>
@@ -39,10 +38,7 @@ export function PoolListSearch() {
                     isLoading={isSearching}
                     _loading={{ color: 'white' }}
                     onClick={() => {
-                        if (searchText !== '') {
-                            setSearchText('');
-                            refetch({ ...state, textSearch: null, skip: 0 });
-                        }
+                        if (searchText !== '') setSearchText('');
                     }}
                 />
             </InputRightElement>

--- a/modules/pools/components/PoolListTop.tsx
+++ b/modules/pools/components/PoolListTop.tsx
@@ -4,8 +4,6 @@ import { PoolListSearch } from '~/modules/pools/components/PoolListSearch';
 import { Filter } from 'react-feather';
 import { PoolListTokenMultiSelect } from '~/modules/pools/components/PoolListTokenMultiSelect';
 import { PoolListFilterMultiSelect } from '~/modules/pools/components/PoolListFilterMultiSelect';
-import { PoolListAttributeMultiSelect } from '~/modules/pools/components/PoolListAttributeMultiSelect';
-import { useBoolean } from '@chakra-ui/hooks';
 import { usePoolList } from '~/modules/pools/usePoolList';
 import { FadeInOutBox } from '~/components/animation/FadeInOutBox';
 

--- a/modules/pools/usePoolList.tsx
+++ b/modules/pools/usePoolList.tsx
@@ -30,11 +30,12 @@ export const DEFAULT_POOL_LIST_QUERY_VARS: PoolsQueryVariables = {
 const poolListStateVar = makeVar<PoolsQueryVariables>(DEFAULT_POOL_LIST_QUERY_VARS);
 const showMyInvestmentsVar = makeVar(false);
 const showFiltersVar = makeVar(false);
+const searchTextVar = makeVar('');
 
 export function _usePoolList() {
     const state = useReactiveVar(poolListStateVar);
     const showMyInvestments = useReactiveVar(showMyInvestmentsVar);
-    const [isSearching, isSearchingToggle] = useBoolean();
+    const searchText = useReactiveVar(searchTextVar);
     const [isSorting, isSortingToggle] = useBoolean();
 
     const {
@@ -103,6 +104,10 @@ export function _usePoolList() {
         showMyInvestmentsVar(show);
     }
 
+    function setSearchText(text: string) {
+        searchTextVar(text);
+    }
+
     function toggleFilterVisibility() {
         showFiltersVar(!showFiltersVar());
     }
@@ -154,6 +159,8 @@ export function _usePoolList() {
         showFilters: useReactiveVar(showFiltersVar),
         setPoolIds,
         clearPoolIds,
+        searchText,
+        setSearchText,
     };
 }
 


### PR DESCRIPTION
- Moved searchText to usePoolList so the value would persist after navigation
- Changed trigger to submitSearch to a useEffect that reacts on searchText. Setting the searchText is async.
- Search was not available on mobile. It is possible to add a search, change screen size, then search is set but user doesn't have access to clear or set. Added text search box to filter modal, but open to move it somewhere else ...
- 
![image](https://user-images.githubusercontent.com/99622829/187106913-0d7777fb-6d45-481c-860a-784d8a94e8f4.png)
