### PR TITLE
155 invest preview showing incorrect values for you can invest and max proportional

### DIFF
--- a/modules/pool/invest/components/PoolInvestProportional.tsx
+++ b/modules/pool/invest/components/PoolInvestProportional.tsx
@@ -21,7 +21,7 @@ import { PoolInvestSummary } from '~/modules/pool/invest/components/PoolInvestSu
 import { useGetTokens } from '~/lib/global/useToken';
 import { useEffect, useState } from 'react';
 import { usePoolJoinGetProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount';
-import { usePoolGetMaxProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount';
+import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUserTokenBalancesInWallet';
 import { mapValues, isEmpty } from 'lodash';
 import { oldBnum } from '~/lib/services/pool/lib/old-big-number';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
@@ -42,7 +42,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
     const { data } = usePoolJoinGetProportionalInvestmentAmount();
     const { selectedInvestTokens } = useInvest();
     const { data: hasBatchRelayerApproval } = useHasBatchRelayerApproval();
-    const { tokenOptionsWithHighestValue } = usePoolGetMaxProportionalInvestmentAmount();
+    const { tokenOptionsWithHighestValue } = usePoolUserTokenBalancesInWallet();
 
     const scaledProportionalSuggestions = mapValues(data || {}, (val, address) =>
         oldBnum(val)

--- a/modules/pool/invest/components/PoolInvestProportional.tsx
+++ b/modules/pool/invest/components/PoolInvestProportional.tsx
@@ -39,7 +39,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
     const { setSelectedOption, selectedOptions, setInputAmounts, zapEnabled } = useInvestState();
     const [proportionalPercent, setProportionalPercent] = useState(25);
     const { data } = usePoolJoinGetProportionalInvestmentAmount();
-    const { selectedInvestTokens, userInvestTokenBalances } = useInvest();
+    const { selectedInvestTokens } = useInvest();
     const { data: hasBatchRelayerApproval } = useHasBatchRelayerApproval();
 
     const scaledProportionalSuggestions = mapValues(data || {}, (val, address) =>
@@ -53,13 +53,6 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
     useEffect(() => {
         setInputAmounts(scaledProportionalSuggestions);
     }, [JSON.stringify(scaledProportionalSuggestions)]);
-
-    /*useEffect(() => {
-        investOptions.forEach((investOption, index) => {
-            const tokenOption = selectedInvestTokens[index];
-            const amount = scaledProportionalSuggestions[tokenOption.address];
-        });
-    }, []);*/
 
     return (
         <Box mt="4">
@@ -100,10 +93,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
                                     <Box flex="1">
                                         <TokenSelectInline
                                             tokenOptions={option.tokenOptions}
-                                            selectedAddress={
-                                                selectedOptions[`${option.poolTokenIndex}`] ||
-                                                option.tokenOptions[0].address
-                                            }
+                                            selectedAddress={selectedOptions[`${option.poolTokenIndex}`]}
                                             onOptionSelect={(address) =>
                                                 setSelectedOption(option.poolTokenIndex, address)
                                             }

--- a/modules/pool/invest/components/PoolInvestProportional.tsx
+++ b/modules/pool/invest/components/PoolInvestProportional.tsx
@@ -21,7 +21,8 @@ import { PoolInvestSummary } from '~/modules/pool/invest/components/PoolInvestSu
 import { useGetTokens } from '~/lib/global/useToken';
 import { useEffect, useState } from 'react';
 import { usePoolJoinGetProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount';
-import { mapValues } from 'lodash';
+import { usePoolGetMaxProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount';
+import { mapValues, isEmpty } from 'lodash';
 import { oldBnum } from '~/lib/services/pool/lib/old-big-number';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
 import { CardRow } from '~/components/card/CardRow';
@@ -41,6 +42,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
     const { data } = usePoolJoinGetProportionalInvestmentAmount();
     const { selectedInvestTokens } = useInvest();
     const { data: hasBatchRelayerApproval } = useHasBatchRelayerApproval();
+    const { tokenOptionsWithHighestValue } = usePoolGetMaxProportionalInvestmentAmount();
 
     const scaledProportionalSuggestions = mapValues(data || {}, (val, address) =>
         oldBnum(val)
@@ -53,6 +55,17 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
     useEffect(() => {
         setInputAmounts(scaledProportionalSuggestions);
     }, [JSON.stringify(scaledProportionalSuggestions)]);
+
+    //set inital selected options if not set, for tokens with more than 1 tokenOption
+    useEffect(() => {
+        if (isEmpty(selectedOptions)) {
+            tokenOptionsWithHighestValue.map((token, index) => {
+                if (token.hasMultipleTokenOptions) {
+                    setSelectedOption(index, token.address);
+                }
+            });
+        }
+    }, []);
 
     return (
         <Box mt="4">

--- a/modules/pool/invest/components/PoolInvestProportional.tsx
+++ b/modules/pool/invest/components/PoolInvestProportional.tsx
@@ -106,7 +106,10 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
                                     <Box flex="1">
                                         <TokenSelectInline
                                             tokenOptions={option.tokenOptions}
-                                            selectedAddress={selectedOptions[`${option.poolTokenIndex}`]}
+                                            selectedAddress={
+                                                selectedOptions[`${option.poolTokenIndex}`] ||
+                                                option.tokenOptions[0].address
+                                            }
                                             onOptionSelect={(address) =>
                                                 setSelectedOption(option.poolTokenIndex, address)
                                             }

--- a/modules/pool/invest/lib/useInvest.ts
+++ b/modules/pool/invest/lib/useInvest.ts
@@ -49,25 +49,6 @@ export function useInvest() {
                 ).length > 0,
         ).length === pool.investConfig.options.length;
 
-    //set inital selected options if not set, for tokens with more than 1 tokenOption
-    useEffect(() => {
-        if (isEmpty(selectedOptions)) {
-            pool.investConfig.options.map((option, index) => {
-                if (option.tokenOptions.length > 1) {
-                    const tokensOptionsWithAmounts = option.tokenOptions.map((token) => ({
-                        ...token,
-                        amount: getUserBalanceUSDForToken(token.address),
-                    }));
-
-                    const largestUSDtokenAddress = tokensOptionsWithAmounts.reduce((previous, current) =>
-                        previous.amount > current.amount ? previous : current,
-                    ).address;
-                    setSelectedOption(index, largestUSDtokenAddress);
-                }
-            });
-        }
-    }, []);
-
     const totalInvestValue = sumBy(selectedInvestTokensWithAmounts, priceForAmount);
     const isInvestingWithEth = !!selectedInvestTokens.find((token) => isEth(token.address));
 

--- a/modules/pool/invest/lib/useInvest.ts
+++ b/modules/pool/invest/lib/useInvest.ts
@@ -11,18 +11,18 @@ import { usePool } from '~/modules/pool/lib/usePool';
 
 export function useInvest() {
     const { pool } = usePool();
-    const { setSelectedOption, selectedOptions, inputAmounts, zapEnabled } = useInvestState();
+    const { selectedOptions, inputAmounts, zapEnabled } = useInvestState();
     const { getUserBalanceForToken, userPoolTokenBalances, getUserBalanceUSDForToken } =
         usePoolUserTokenBalancesInWallet();
     const { priceForAmount } = useGetTokens();
 
-    const selectedInvestTokens: GqlPoolToken[] = pool.investConfig.options.map((option) => {
-        return selectedOptions[`${option.poolTokenIndex}`]
+    const selectedInvestTokens: GqlPoolToken[] = pool.investConfig.options.map((option) =>
+        selectedOptions[`${option.poolTokenIndex}`]
             ? option.tokenOptions.find(
                   (tokenOption) => tokenOption.address === selectedOptions[`${option.poolTokenIndex}`],
               )!
-            : option.tokenOptions[0];
-    });
+            : option.tokenOptions[0],
+    );
 
     const selectedInvestTokensWithAmounts = selectedInvestTokens.map((token) => ({
         ...token,

--- a/modules/pool/invest/lib/useInvest.ts
+++ b/modules/pool/invest/lib/useInvest.ts
@@ -11,8 +11,7 @@ import { usePool } from '~/modules/pool/lib/usePool';
 export function useInvest() {
     const { pool } = usePool();
     const { selectedOptions, inputAmounts, zapEnabled } = useInvestState();
-    const { getUserBalanceForToken, userPoolTokenBalances, getUserBalanceUSDForToken } =
-        usePoolUserTokenBalancesInWallet();
+    const { getUserBalanceForToken, userPoolTokenBalances } = usePoolUserTokenBalancesInWallet();
     const { priceForAmount } = useGetTokens();
 
     const selectedInvestTokens: GqlPoolToken[] = pool.investConfig.options.map((option) =>

--- a/modules/pool/invest/lib/useInvest.ts
+++ b/modules/pool/invest/lib/useInvest.ts
@@ -1,10 +1,9 @@
-import { useEffect } from 'react';
 import { TokenAmountHumanReadable } from '~/lib/services/token/token-types';
 import { useInvestState } from '~/modules/pool/invest/lib/useInvestState';
 import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUserTokenBalancesInWallet';
 import { isEth, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
 import { GqlPoolToken } from '~/apollo/generated/graphql-codegen-generated';
-import { sumBy, isEmpty } from 'lodash';
+import { sumBy } from 'lodash';
 import { useGetTokens } from '~/lib/global/useToken';
 import { oldBnum } from '~/lib/services/pool/lib/old-big-number';
 import { usePool } from '~/modules/pool/lib/usePool';

--- a/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount.ts
@@ -1,6 +1,6 @@
 import { useUserAccount } from '~/lib/user/useUserAccount';
 import { sortBy, sumBy } from 'lodash';
-import { isEth, replaceEthWithWeth } from '~/lib/services/token/token-util';
+import { replaceEthWithWeth } from '~/lib/services/token/token-util';
 import { useQuery } from 'react-query';
 import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUserTokenBalancesInWallet';
 import { useGetTokens } from '~/lib/global/useToken';
@@ -40,7 +40,7 @@ export function usePoolGetMaxProportionalInvestmentAmount() {
         'normalizedAmount',
     )[0];
 
-    const query = useQuery(
+    return useQuery(
         [
             {
                 key: 'poolGetMaxProportionalInvestmentAmount',
@@ -52,9 +52,7 @@ export function usePoolGetMaxProportionalInvestmentAmount() {
         async ({ queryKey }) => {
             const fixedAmount = {
                 ...tokenWithSmallestValue,
-                address: isEth(tokenWithSmallestValue.address)
-                    ? replaceEthWithWeth(tokenWithSmallestValue.address)
-                    : tokenWithSmallestValue.address,
+                address: replaceEthWithWeth(tokenWithSmallestValue.address),
             };
 
             if (!poolService.joinGetProportionalSuggestionForFixedAmount) {
@@ -70,6 +68,4 @@ export function usePoolGetMaxProportionalInvestmentAmount() {
         },
         { enabled: true, staleTime: 0, cacheTime: 0 },
     );
-
-    return { ...query };
 }

--- a/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount.ts
@@ -14,14 +14,18 @@ export function usePoolGetMaxProportionalInvestmentAmount() {
     const { userAddress } = useUserAccount();
     const { getUserBalanceForToken } = usePoolUserTokenBalancesInWallet();
     const { userInvestTokenBalances, selectedInvestTokens } = useInvest();
-    const tokenOptionsWithHighestValue: TokenAmountHumanReadable[] = pool.investConfig.options.map((option) => {
+    const tokenOptionsWithHighestValue = pool.investConfig.options.map((option) => {
         const tokenWithHighestValue = orderBy(
             option.tokenOptions,
             (tokenOption) => priceForAmount({ ...tokenOption, amount: getUserBalanceForToken(tokenOption.address) }),
             'desc',
         )[0].address;
 
-        return { address: tokenWithHighestValue, amount: getUserBalanceForToken(tokenWithHighestValue) };
+        return {
+            address: tokenWithHighestValue,
+            amount: getUserBalanceForToken(tokenWithHighestValue),
+            hasMultipleTokenOptions: option.tokenOptions.length > 1,
+        };
     });
 
     const tokenWithSmallestValue = sortBy(
@@ -50,7 +54,7 @@ export function usePoolGetMaxProportionalInvestmentAmount() {
         'normalizedAmount',
     )[0];
 
-    return useQuery(
+    const query = useQuery(
         [
             {
                 key: 'poolGetMaxProportionalInvestmentAmount',
@@ -79,4 +83,6 @@ export function usePoolGetMaxProportionalInvestmentAmount() {
         },
         { enabled: true, staleTime: 0, cacheTime: 0 },
     );
+
+    return { ...query, tokenOptionsWithHighestValue };
 }

--- a/modules/pool/lib/usePoolUserTokenBalancesInWallet.tsx
+++ b/modules/pool/lib/usePoolUserTokenBalancesInWallet.tsx
@@ -20,11 +20,16 @@ export function _usePoolUserTokenBalancesInWallet() {
         return userBalances.find((balance) => address === balance.address)?.amount || '0';
     }
 
+    function getUserBalanceUSDForToken(address: string): number {
+        return priceForAmount({ address: address, amount: getUserBalance(address) });
+    }
+
     return {
         ...userBalancesQuery,
         userPoolTokenBalances: userBalances,
         investableAmount,
         getUserBalanceForToken,
+        getUserBalanceUSDForToken,
     };
 }
 

--- a/modules/pool/lib/usePoolUserTokenBalancesInWallet.tsx
+++ b/modules/pool/lib/usePoolUserTokenBalancesInWallet.tsx
@@ -20,16 +20,11 @@ export function _usePoolUserTokenBalancesInWallet() {
         return userBalances.find((balance) => address === balance.address)?.amount || '0';
     }
 
-    function getUserBalanceUSDForToken(address: string): number {
-        return priceForAmount({ address: address, amount: getUserBalance(address) });
-    }
-
     return {
         ...userBalancesQuery,
         userPoolTokenBalances: userBalances,
         investableAmount,
         getUserBalanceForToken,
-        getUserBalanceUSDForToken,
     };
 }
 


### PR DESCRIPTION
Calculations for "You Can Invest" and "Max Proportional" are done now only with "investable tokens". If a token includes mulitple options [ftm/wftm, or nested pool] then only the token with the largest value will be use.

- Move the `tokenOptionsWithHighestValue` to usePoolUserTokenBalancesInWallet() as a more appropriate location as it's used for more than just Proportional Investments. 

![image](https://user-images.githubusercontent.com/99622829/187097356-c3eaa31a-ca3e-421c-a30f-71d810df76dc.png)
