### PR TITLE
Not prompting for BPT approval on invest

### DIFF
--- a/lib/util/useAllowances.ts
+++ b/lib/util/useAllowances.ts
@@ -39,13 +39,12 @@ export function useAllowances(account: string | null, tokens: TokenBase[], contr
     }
 
     function hasApprovalForAmount(address: string, amount: AmountHumanReadable) {
+        if (amount === '') return true;
+
         const allowance = allowances.find((allowance) => allowance.address === address.toLowerCase())?.amount || '0';
+        if (parseFloat(allowance) === 0) return false;
+
         const decimals = tokens.find((token) => token.address === address)?.decimals || 18;
-
-        if (amount === '') {
-            return true;
-        }
-
         return parseUnits(allowance, decimals).gte(parseUnits(amount, decimals));
     }
 

--- a/modules/pool/stake/PoolStakeModal.tsx
+++ b/modules/pool/stake/PoolStakeModal.tsx
@@ -64,12 +64,19 @@ export function PoolStakeModal({ isOpen, onOpen, onClose }: Props) {
     const loading = isLoadingAllowances || isLoadingBalances;
 
     useEffect(() => {
-        if (!loading && steps === null) {
+        if (!loading) {
             const hasApproval = hasApprovalToStakeAmount(userWalletBptBalance);
 
             setSteps([
                 ...(!hasApproval
-                    ? [{ id: 'approve', type: 'other' as const, buttonText: 'Approve BPT', tooltipText: 'Approve BPT' }]
+                    ? [
+                          {
+                              id: 'approve',
+                              type: 'other' as const,
+                              buttonText: 'Approve BPT',
+                              tooltipText: 'Approve BPT',
+                          },
+                      ]
                     : []),
                 {
                     id: 'stake',
@@ -79,7 +86,7 @@ export function PoolStakeModal({ isOpen, onOpen, onClose }: Props) {
                 },
             ]);
         }
-    }, [loading]);
+    }, [loading, isOpen]);
 
     useEffect(() => {
         if (isOpen && userWalletBptBalance) {


### PR DESCRIPTION
- the staking modal is not refreshing once the investment is finished. removed check for whether steps are set (they get set on the initial render, but they need to be reset). And trigger the useEffect that updates the steps on `isOpen` also. 

- included a refactor to `hasApprovalForAmount`. the check for amount being empty moved to the beginning of the function. And it seems if allowance is set to zero or not set at all `( || '0')` then this function will return false.