### PR TITLE
Handle invest transaction error gracefully

### DIFF
--- a/lib/util/useSubmitTransaction.tsx
+++ b/lib/util/useSubmitTransaction.tsx
@@ -115,7 +115,7 @@ export function useSubmitTransaction({ config, transactionType, waitForConfig }:
                     render: ({ onClose }) => (
                         <TransactionStatusToast
                             type={transactionType}
-                            status={error ? 'ERROR' : 'CONFIRMED'}
+                            status={error || data?.status === 0 ? 'ERROR' : 'CONFIRMED'}
                             text={toastText.current}
                             onClose={onClose}
                             txHash={data?.transactionHash || ''}


### PR DESCRIPTION
When a transaction fails the `transactionReceipt.status === 0` (on success it equals 1). Checking for status and for the error when displaying toast.

Tested on FTM and OP, for Harvest and Approved. Unable to get invest (or other transaction) to fail reliably.

