### PR TITLE
Approving the batch relayer does not refresh on success

### DIFF
--- a/lib/util/useHasBatchRelayerApproval.ts
+++ b/lib/util/useHasBatchRelayerApproval.ts
@@ -3,8 +3,6 @@ import { useNetworkConfig } from '~/lib/global/useNetworkConfig';
 import { vaultContractConfig } from '~/lib/util/useSubmitTransaction';
 import { useUserAccount } from '~/lib/user/useUserAccount';
 
-const ALLOWANCES_CACHE_TIME_MS = 30_000;
-
 export function useHasBatchRelayerApproval() {
     const networkConfig = useNetworkConfig();
     const { userAddress } = useUserAccount();
@@ -13,7 +11,7 @@ export function useHasBatchRelayerApproval() {
         ...vaultContractConfig,
         enabled: typeof userAddress === 'string',
         args: [userAddress, networkConfig.balancer.batchRelayer],
-        //cacheTime: cacheTimeMs,
         functionName: 'hasApprovedRelayer',
+        watch: true,
     });
 }


### PR DESCRIPTION
I'm not sure if there are any side effects from adding `watch=true` to useContractRead. It does cause the UI to update immediately but the documentation is pretty thin on what it does.