### PR TITLE
make rpc configurable with fallback

### DIFF
--- a/lib/config/fantom.ts
+++ b/lib/config/fantom.ts
@@ -22,8 +22,12 @@ export const fantomNetworkConfig: NetworkConfig = {
         nativeAssetId: 'fantom',
         platformId: 'fantom',
     },
-    rpcUrl: 'https://rpc.ftm.tools',
-    //rpcUrl: 'https://rpc.ankr.com/fantom',
+
+    rpcUrl: {
+        internal: 'https://rpc.ftm.tools',
+        //rpcUrl: 'https://rpc.ankr.com/fantom',
+        client: 'https://rpc.ftm.tools',
+    },
     multicall: '0x66335d7ad8011f6aa3f48aadcb523b62b38ed961',
     beets: {
         address: '0xf24bcf4d1e507740041c9cfd2dddb29585adce1e',

--- a/lib/config/network-config-type.ts
+++ b/lib/config/network-config-type.ts
@@ -15,7 +15,10 @@ export interface NetworkConfig {
     };
     wethAddress: string;
     wethAddressFormatted: string;
-    rpcUrl: string;
+    rpcUrl: {
+        internal: string;
+        client: string;
+    };
     coingecko: {
         nativeAssetId: string;
         platformId: string;

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -21,8 +21,10 @@ export const optimismNetworkConfig: NetworkConfig = {
         nativeAssetId: 'optimism',
         platformId: 'optimism',
     },
-    // rpcUrl: 'https://rpc.ankr.com/optimism',
-    rpcUrl: process.env.RPC_URL || 'https://rpc.ankr.com/optimism',
+    rpcUrl: {
+        internal: process.env.INTERNAL_RPC_URL || 'https://rpc.ankr.com/optimism',
+        client: 'https://rpc.ankr.com/optimism',
+    },
     multicall: '0x2dc0e2aa608532da689e89e237df582b783e552c',
     beets: {
         address: '0x97513e975a7fa9072c72c92d8000b0db90b163c5',

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -21,7 +21,8 @@ export const optimismNetworkConfig: NetworkConfig = {
         nativeAssetId: 'optimism',
         platformId: 'optimism',
     },
-    rpcUrl: 'https://rpc.ankr.com/optimism',
+    // rpcUrl: 'https://rpc.ankr.com/optimism',
+    rpcUrl: process.env.RPC_URL || 'https://rpc.ankr.com/optimism',
     multicall: '0x2dc0e2aa608532da689e89e237df582b783e552c',
     beets: {
         address: '0x97513e975a7fa9072c72c92d8000b0db90b163c5',

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -22,7 +22,7 @@ export const optimismNetworkConfig: NetworkConfig = {
         platformId: 'optimism',
     },
     rpcUrl: {
-        internal: process.env.INTERNAL_RPC_URL!,
+        internal: process.env.INTERNAL_RPC_URL || 'https://mainnet.optimism.io',
         client: 'https://rpc.ankr.com/optimism',
     },
     multicall: '0x2dc0e2aa608532da689e89e237df582b783e552c',

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -22,12 +22,12 @@ export const optimismNetworkConfig: NetworkConfig = {
         platformId: 'optimism',
     },
     rpcUrl: {
-        internal: process.env.INTERNAL_RPC_URL ? process.env.INTERNAL_RPC_URL : 'https://mainnet.optimism.io',
+        internal: process.env.INTERNAL_RPC_URL!,
         client: 'https://rpc.ankr.com/optimism',
     },
     multicall: '0x2dc0e2aa608532da689e89e237df582b783e552c',
     beets: {
-        address: '0x97513e975a7fa9072c72c92d8000b0db90b163c5',
+        address: '0x97513e9image.png75a7fa9072c72c92d8000b0db90b163c5',
     },
     fbeets: {
         address: '',

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -22,7 +22,7 @@ export const optimismNetworkConfig: NetworkConfig = {
         platformId: 'optimism',
     },
     rpcUrl: {
-        internal: process.env.INTERNAL_RPC_URL || 'https://mainnet.optimism.io',
+        internal: process.env.NEXT_PUBLIC_INTERNAL_RPC_URL || 'https://mainnet.optimism.io',
         client: 'https://rpc.ankr.com/optimism',
     },
     multicall: '0x2dc0e2aa608532da689e89e237df582b783e552c',

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -22,7 +22,7 @@ export const optimismNetworkConfig: NetworkConfig = {
         platformId: 'optimism',
     },
     rpcUrl: {
-        internal: process.env.INTERNAL_RPC_URL || 'https://rpc.ankr.com/optimism',
+        internal: process.env.INTERNAL_RPC_URL ? process.env.INTERNAL_RPC_URL : 'https://mainnet.optimism.io',
         client: 'https://rpc.ankr.com/optimism',
     },
     multicall: '0x2dc0e2aa608532da689e89e237df582b783e552c',

--- a/lib/global/network.ts
+++ b/lib/global/network.ts
@@ -79,7 +79,6 @@ const responseBackend = configureChains(
 
 export const networkChainDefinitions = response.chains;
 export const networkProvider = responseBackend.provider({ chainId: parseInt(networkConfig.chainId) });
-console.log(process.env.INTERNAL_RPC_URL);
 
 const { connectors } = getDefaultWallets({
     appName: networkConfig.appName,

--- a/lib/global/network.ts
+++ b/lib/global/network.ts
@@ -18,7 +18,7 @@ const response = configureChains(
                 decimals: networkConfig.eth.decimals,
             },
             rpcUrls: {
-                default: networkConfig.rpcUrl,
+                default: networkConfig.rpcUrl.client,
             },
             blockExplorers: {
                 etherscan: {
@@ -35,13 +35,51 @@ const response = configureChains(
     ],
     [
         batchJsonRpcProvider({
-            rpc: (chain) => ({ http: networkConfig.rpcUrl }),
+            rpc: (chain) => ({ http: networkConfig.rpcUrl.client }),
+        }),
+    ],
+);
+
+const responseBackend = configureChains(
+    [
+        {
+            id: parseInt(networkConfig.chainId),
+            network: networkConfig.networkShortName,
+            name: networkConfig.networkName,
+            ...(networkConfig.chainId === '250' && {
+                iconUrl: 'https://assets.coingecko.com/coins/images/4001/large/Fantom.png?1558015016',
+            }),
+            nativeCurrency: {
+                name: networkConfig.eth.name,
+                symbol: networkConfig.eth.symbol,
+                decimals: networkConfig.eth.decimals,
+            },
+            rpcUrls: {
+                default: networkConfig.rpcUrl.internal,
+            },
+            blockExplorers: {
+                etherscan: {
+                    name: networkConfig.etherscanName,
+                    url: networkConfig.etherscanUrl,
+                },
+                default: {
+                    name: networkConfig.etherscanName,
+                    url: networkConfig.etherscanUrl,
+                },
+            },
+            testnet: networkConfig.testnet,
+        },
+    ],
+    [
+        batchJsonRpcProvider({
+            rpc: (chain) => ({ http: networkConfig.rpcUrl.internal }),
         }),
     ],
 );
 
 export const networkChainDefinitions = response.chains;
-export const networkProvider = response.provider({ chainId: parseInt(networkConfig.chainId) });
+export const networkProvider = responseBackend.provider({ chainId: parseInt(networkConfig.chainId) });
+console.log(process.env.INTERNAL_RPC_URL);
 
 const { connectors } = getDefaultWallets({
     appName: networkConfig.appName,


### PR DESCRIPTION
How about this? Since the alchemy rpc has an api key, I'd like to provide it via env var. And also like this it could be easy changeable without the need to push to git.

For the UI to pick up the change in the config, can I rebuild it from vercel?