### PR TITLE
update claim all in navbar

### DIFF
--- a/modules/nav/NavbarPendingRewards.tsx
+++ b/modules/nav/NavbarPendingRewards.tsx
@@ -95,9 +95,8 @@ export function NavbarPendingRewards() {
                         templateAreas={{
                             base: `"pool"
                                     "reliquary"`,
-                            lg: `"reliquary pool"`,
+                            lg: `"pool reliquary"`,
                         }}
-                        width="full"
                     >
                         {networkConfig.maBeetsEnabled && (
                             <GridItem area="reliquary">

--- a/modules/nav/NavbarPendingRewards.tsx
+++ b/modules/nav/NavbarPendingRewards.tsx
@@ -84,7 +84,7 @@ export function NavbarPendingRewards() {
                     <Skeleton />
                 </Button>
             </PopoverTrigger>
-            <PopoverContent bgColor="beets.base.900" _focus={{ boxShadow: 'none' }} w="full">
+            <PopoverContent bgColor="beets.base.900" _focus={{ boxShadow: 'none' }} w="full" minW="320px">
                 <PopoverArrow color="beets.base.900" />
                 <PopoverCloseButton />
                 <PopoverHeader borderBottomWidth="0">Liquidity incentives</PopoverHeader>


### PR DESCRIPTION
- hide reliquary claim all on OP
- move to grid to manage order (for mobile)

to do: enable scroll on mobile, workaround for now is to put pool rewards first (on mobile) assuming they are the priority -> issue #246 

![image](https://user-images.githubusercontent.com/20125808/223046838-f535eedf-b0b2-460e-bec4-bdd8e199179c.png)
![image](https://user-images.githubusercontent.com/20125808/223046939-a5213431-ae2f-4d33-b629-576f24f57be9.png)
