### PR TITLE
Proportional invest issue

### DIFF
--- a/lib/services/pool/lib/pool-proportional-invest.service.ts
+++ b/lib/services/pool/lib/pool-proportional-invest.service.ts
@@ -2,7 +2,7 @@ import { sortBy, sum } from 'lodash';
 import { GqlPoolWeighted } from '~/apollo/generated/graphql-codegen-generated';
 import { TokenAmountHumanReadable } from '../../token/token-types';
 import { replaceEthWithWeth } from '../../token/token-util';
-import { getBptOutForToken, calculateAmountIn, calculateBptOut } from './util';
+import { getBptOutForToken, calculateAmountIn, calculateBptOut, calculateAmountInF, calculateBptOutF } from './util';
 import { oldBnumSum, oldBnumToHumanReadable } from './old-big-number';
 
 export class PoolProportionalInvestService {
@@ -15,6 +15,10 @@ export class PoolProportionalInvestService {
             this.pool.tokens.map((token) => {
                 if (token.__typename === 'GqlPoolTokenPhantomStable') {
                     // another loop to find the smallest bptOut amount for the nested stable pool
+                    // const nestedTokens = token.pool.tokens.map((poolToken) =>
+                    //     getBptOutForToken(userInvestTokenBalances, poolToken, token.pool.totalShares),
+                    // );
+
                     const nestedTokens = token.pool.tokens.map((poolToken) => {
                         const bptOut = getBptOutForToken(userInvestTokenBalances, poolToken, token.pool.totalShares);
                         return {
@@ -25,18 +29,43 @@ export class PoolProportionalInvestService {
                     });
 
                     const smallestNestedBptOutAmountArray = sortBy(nestedTokens, 'bptOutFloat');
+                    //const smallestNestedBptOutAmountArray = sortBy(nestedTokens, 'bptOut');
 
                     // calculate the proportional amounts based on the smallest bpt token amount
                     // and sum them to get the 'amountIn' for the nested stable pool bptOut calculation
+
+                    // const amount = sum(
+                    //     smallestNestedBptOutAmountArray.map((nestedToken) =>
+                    //         calculateAmountInF(
+                    //             token.pool.totalShares,
+                    //             smallestNestedBptOutAmountArray[0].bptOut.toString(),
+                    //             nestedToken.token.balance,
+                    //         ),
+                    //     ),
+                    // ).toFixed(smallestNestedBptOutAmountArray[0].token.decimals);
+
                     const amount = oldBnumSum(
                         smallestNestedBptOutAmountArray.map((nestedToken) =>
                             calculateAmountIn(
                                 token.pool.totalShares,
                                 smallestNestedBptOutAmountArray[0].bptOut,
-                                nestedToken,
-                            ),
+                                nestedToken.token.balance,
+                            ).toString(),
                         ),
                     ).toFixed(smallestNestedBptOutAmountArray[0].token.decimals || 18);
+
+                    // return {
+                    //     bptOut: calculateBptOutF(
+                    //         this.pool.dynamicData.totalShares,
+                    //         amount,
+                    //         token.balance,
+                    //         token.priceRate,
+                    //     ),
+                    //     token: {
+                    //         address: smallestNestedBptOutAmountArray[0].token.address,
+                    //         amount,
+                    //     },
+                    // };
 
                     return {
                         // need to sort on bptOut
@@ -52,6 +81,8 @@ export class PoolProportionalInvestService {
                     };
                 } else {
                     // the function will take either 'GqlPoolToken' or 'GqlPoolTokenLinear'
+                    //return getBptOutForToken(userInvestTokenBalances, token, this.pool.dynamicData.totalShares);
+
                     const bptOut = getBptOutForToken(userInvestTokenBalances, token, this.pool.dynamicData.totalShares);
                     return {
                         ...bptOut,
@@ -64,12 +95,9 @@ export class PoolProportionalInvestService {
         );
 
         const fixedAmount = {
-            //amount: smallestBptOutAmount[0].token.amount,
-            amount: '2754.739210',
+            amount: smallestBptOutAmount[0].token.amount,
             address: replaceEthWithWeth(smallestBptOutAmount[0].token.address || ''),
         };
-
-        console.log({ fixedAmount });
 
         return fixedAmount;
     }

--- a/lib/services/pool/lib/pool-proportional-invest.service.ts
+++ b/lib/services/pool/lib/pool-proportional-invest.service.ts
@@ -135,9 +135,8 @@ export class PoolProportionalInvestService {
     ) {
         const balanceScaled = oldBnumScale(balance, decimals).times(priceRate);
         const amountRatio = oldBnumScale(amountIn, decimals).div(balanceScaled);
-        const bptOut = oldBnumScale(bptTotalSupply, 18).times(amountRatio);
 
-        return bptOut;
+        return oldBnumScale(bptTotalSupply, 18).times(amountRatio);
     }
 
     private calculateAmountIn(bptTotalSupply: string, bptIn: OldBigNumber, balance: string) {

--- a/lib/services/pool/lib/pool-proportional-invest.service.ts
+++ b/lib/services/pool/lib/pool-proportional-invest.service.ts
@@ -1,0 +1,76 @@
+import { sortBy, sum } from 'lodash';
+import { GqlPoolWeighted } from '~/apollo/generated/graphql-codegen-generated';
+import { TokenAmountHumanReadable } from '../../token/token-types';
+import { replaceEthWithWeth } from '../../token/token-util';
+import { getBptOutForToken, calculateAmountIn, calculateBptOut } from './util';
+import { oldBnumSum, oldBnumToHumanReadable } from './old-big-number';
+
+export class PoolProportionalInvestService {
+    constructor(private pool: GqlPoolWeighted) {}
+
+    public async getProportionalSuggestion(userInvestTokenBalances: TokenAmountHumanReadable[]) {
+        // loop through the pool tokens to find out which token (and amount) would give the smallest bptOut amount
+        // so we can use that as the base to calculate the proportions of the other tokens
+        const smallestBptOutAmount = sortBy(
+            this.pool.tokens.map((token) => {
+                if (token.__typename === 'GqlPoolTokenPhantomStable') {
+                    // another loop to find the smallest bptOut amount for the nested stable pool
+                    const nestedTokens = token.pool.tokens.map((poolToken) => {
+                        const bptOut = getBptOutForToken(userInvestTokenBalances, poolToken, token.pool.totalShares);
+                        return {
+                            ...bptOut,
+                            // need to sort on bptOutFloat
+                            bptOutFloat: parseFloat(oldBnumToHumanReadable(bptOut.bptOut)),
+                        };
+                    });
+
+                    const smallestNestedBptOutAmountArray = sortBy(nestedTokens, 'bptOutFloat');
+
+                    // calculate the proportional amounts based on the smallest bpt token amount
+                    // and sum them to get the 'amountIn' for the nested stable pool bptOut calculation
+                    const amount = oldBnumSum(
+                        smallestNestedBptOutAmountArray.map((nestedToken) =>
+                            calculateAmountIn(
+                                token.pool.totalShares,
+                                smallestNestedBptOutAmountArray[0].bptOut,
+                                nestedToken,
+                            ),
+                        ),
+                    ).toFixed(smallestNestedBptOutAmountArray[0].token.decimals || 18);
+
+                    return {
+                        // need to sort on bptOut
+                        bptOut: parseFloat(
+                            oldBnumToHumanReadable(
+                                calculateBptOut(this.pool.dynamicData.totalShares, amount, token.balance),
+                            ),
+                        ),
+                        token: {
+                            address: smallestNestedBptOutAmountArray[0].token.address,
+                            amount,
+                        },
+                    };
+                } else {
+                    // the function will take either 'GqlPoolToken' or 'GqlPoolTokenLinear'
+                    const bptOut = getBptOutForToken(userInvestTokenBalances, token, this.pool.dynamicData.totalShares);
+                    return {
+                        ...bptOut,
+                        // need to sort on bptOut
+                        bptOut: parseFloat(oldBnumToHumanReadable(bptOut.bptOut)),
+                    };
+                }
+            }),
+            'bptOut',
+        );
+
+        const fixedAmount = {
+            //amount: smallestBptOutAmount[0].token.amount,
+            amount: '2754.739210',
+            address: replaceEthWithWeth(smallestBptOutAmount[0].token.address || ''),
+        };
+
+        console.log({ fixedAmount });
+
+        return fixedAmount;
+    }
+}

--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -592,7 +592,7 @@ export function calculateAmountIn(bptTotalSupply: string, bptIn: OldBigNumber, b
     const bptRatio = bptIn.div(oldBnumScale(bptTotalSupply, 18));
     const amountIn = oldBnumScale(balance, 18).times(bptRatio);
 
-    // return human readable so we can sum 6 & 18 decimal big numbers (alternative?)
+    // return human readable so we can convert a sum to the correct decimals again (alternative?)
     return oldBnumToHumanReadable(amountIn);
 }
 

--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -574,10 +574,6 @@ export function tokenAmountsAllZero(tokenAmounts: TokenAmountHumanReadable[]) {
     return tokenAmounts.filter((amount) => parseFloat(amount.amount) === 0).length === tokenAmounts.length;
 }
 
-export function calculateBptOutF(bptTotalSupply: string, amountIn: string, balance: string, priceRate: string) {
-    return parseFloat(bptTotalSupply) * (parseFloat(amountIn || '') / (parseFloat(balance) * parseFloat(priceRate)));
-}
-
 export function calculateBptOut(
     bptTotalSupply: string,
     amountIn: string,
@@ -590,10 +586,6 @@ export function calculateBptOut(
     const bptOut = oldBnumScale(bptTotalSupply, 18).times(amountRatio);
 
     return bptOut;
-}
-
-export function calculateAmountInF(bptTotalSupply: string, bptIn: string, balance: string) {
-    return parseFloat(balance) * (parseFloat(bptIn) / parseFloat(bptTotalSupply));
 }
 
 export function calculateAmountIn(bptTotalSupply: string, bptIn: OldBigNumber, balance: string) {
@@ -641,7 +633,6 @@ export function getBptOutForToken(
             : poolToken.decimals;
 
     return {
-        //bptOut: calculateBptOutF(bptTotalSupply, investToken.amount, poolToken.balance, poolToken.priceRate),
         bptOut: calculateBptOut(
             bptTotalSupply,
             investToken.amount,
@@ -654,6 +645,5 @@ export function getBptOutForToken(
             decimals,
             balance: poolToken.balance,
         },
-        priceRate: poolToken.priceRate,
     };
 }

--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -573,8 +573,11 @@ export function tokenAmountsAllZero(tokenAmounts: TokenAmountHumanReadable[]) {
 }
 
 export function calculateBptOut(bptTotalSupply: string, amountIn: string, balance: string) {
-    // for now this is only used for sorting
     return parseFloat(bptTotalSupply) * (parseFloat(amountIn || '') / parseFloat(balance));
+}
+
+export function calculateAmountIn(bptTotalSupply: string, bptIn: string, balance: string) {
+    return parseFloat(balance) * (parseFloat(bptIn) / parseFloat(bptTotalSupply));
 }
 
 export function getInvestTokenForLinearPoolToken(
@@ -598,16 +601,18 @@ export function getBptOutForToken(
             ? getInvestTokenForLinearPoolToken(userInvestTokenBalances, poolToken)
             : userInvestTokenBalances.find((balance) => balance.address === poolToken.address)!;
 
+    const decimals =
+        poolToken.__typename === 'GqlPoolTokenLinear'
+            ? poolToken.pool.tokens.find((token) => token.address === investToken.address)?.decimals
+            : poolToken.decimals;
+
     return {
         bptOut: calculateBptOut(bptTotalSupply, investToken.amount, poolToken.balance),
         token: {
             ...investToken,
+            decimals,
+            balance: poolToken.balance,
         },
-        // weight: oldBnumFromBnum(parseUnits(poolToken.totalBalance, poolToken.decimals)).div(
-        //     oldBnumFromBnum(parseUnits(bptTotalSupply, 18)),
-        // ),
-        weight: parseFloat(poolToken.totalBalance) / parseFloat(bptTotalSupply),
-        decimals: poolToken.decimals,
-        priceRate: poolToken.priceRate,
+        priceRate: parseFloat(poolToken.priceRate),
     };
 }

--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -629,6 +629,12 @@ export function getBptOutForToken(
                       balance.address === replaceWethWithEth(poolToken.address),
               )!;
 
+    // for the old weighted boosted pools only the 'selected' token is in the userInvestBalances
+    // so we return null to filter it out in the invest service
+    if (!investToken) {
+        return null;
+    }
+
     const decimals =
         poolToken.__typename === 'GqlPoolTokenLinear'
             ? poolToken.pool.tokens.find((token) => token.address === investToken.address)?.decimals

--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -622,7 +622,7 @@ export function getBptOutForToken(
               )!;
 
     // for the old weighted boosted pools only the 'selected' token is in the userInvestBalances
-    // so we return null to filter it out in the invest service
+    // so we return null to filter out the other tokens in the invest service
     if (!investToken) {
         return null;
     }

--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -6,8 +6,6 @@ import {
     GqlPoolTokenBase,
     GqlPoolTokenLinear,
     GqlPoolTokenPhantomStable,
-    GqlPoolTokenPhantomStableNestedUnion,
-    GqlPoolTokenUnion,
     GqlPoolWeighted,
 } from '~/apollo/generated/graphql-codegen-generated';
 import { AmountHumanReadable, AmountScaledString, TokenAmountHumanReadable } from '~/lib/services/token/token-types';
@@ -17,7 +15,6 @@ import {
     oldBnumScale,
     oldBnumScaleAmount,
     oldBnumToBnum,
-    oldBnumToHumanReadable,
     oldBnumZero,
 } from '~/lib/services/pool/lib/old-big-number';
 import OldBigNumber from 'bignumber.js';
@@ -39,7 +36,6 @@ import { Contract } from '@ethersproject/contracts';
 import { networkConfig } from '~/lib/config/network-config';
 import VaultAbi from '~/lib/abi/VaultAbi.json';
 import { formatFixed } from '@ethersproject/bignumber';
-import { replaceWethWithEth } from '../../token/token-util';
 
 export function poolScaleAmp(amp: string): BigNumber {
     // amp is stored with 3 decimals of precision
@@ -572,78 +568,4 @@ export function poolGetNestedTokenEstimateForPoolTokenAmounts({
 
 export function tokenAmountsAllZero(tokenAmounts: TokenAmountHumanReadable[]) {
     return tokenAmounts.filter((amount) => parseFloat(amount.amount) === 0).length === tokenAmounts.length;
-}
-
-export function calculateBptOut(
-    bptTotalSupply: string,
-    amountIn: string,
-    balance: string,
-    decimals: number = 18,
-    priceRate: string = '1.0',
-) {
-    const balanceScaled = oldBnumScale(balance, decimals).times(priceRate);
-    const amountRatio = oldBnumScale(amountIn, decimals).div(balanceScaled);
-    const bptOut = oldBnumScale(bptTotalSupply, 18).times(amountRatio);
-
-    return bptOut;
-}
-
-export function calculateAmountIn(bptTotalSupply: string, bptIn: OldBigNumber, balance: string) {
-    const bptRatio = bptIn.div(oldBnumScale(bptTotalSupply, 18));
-    const amountIn = oldBnumScale(balance, 18).times(bptRatio);
-
-    // return human readable so we can convert a sum to the correct decimals again (alternative?)
-    return oldBnumToHumanReadable(amountIn);
-}
-
-export function getInvestTokenForLinearPoolToken(
-    userInvestTokenBalances: TokenAmountHumanReadable[],
-    poolToken: GqlPoolTokenUnion | GqlPoolTokenPhantomStableNestedUnion,
-) {
-    return userInvestTokenBalances.find((balance) => {
-        if (poolToken.__typename === 'GqlPoolTokenLinear') {
-            return !!poolToken.pool.tokens.find((nestedPoolToken) => nestedPoolToken.address === balance.address);
-        }
-    })!;
-}
-
-export function getBptOutForToken(
-    userInvestTokenBalances: TokenAmountHumanReadable[],
-    poolToken: GqlPoolTokenUnion | GqlPoolTokenPhantomStableNestedUnion,
-    bptTotalSupply: string,
-) {
-    const investToken =
-        poolToken.__typename === 'GqlPoolTokenLinear'
-            ? getInvestTokenForLinearPoolToken(userInvestTokenBalances, poolToken)
-            : userInvestTokenBalances.find(
-                  (balance) =>
-                      balance.address === poolToken.address ||
-                      balance.address === replaceWethWithEth(poolToken.address),
-              )!;
-
-    // for the old weighted boosted pools only the 'selected' token is in the userInvestBalances
-    // so we return null to filter out the other tokens in the invest service
-    if (!investToken) {
-        return null;
-    }
-
-    const decimals =
-        poolToken.__typename === 'GqlPoolTokenLinear'
-            ? poolToken.pool.tokens.find((token) => token.address === investToken.address)?.decimals
-            : poolToken.decimals;
-
-    return {
-        bptOut: calculateBptOut(
-            bptTotalSupply,
-            investToken.amount,
-            poolToken.balance,
-            poolToken.decimals,
-            poolToken.priceRate,
-        ),
-        token: {
-            ...investToken,
-            decimals,
-            balance: poolToken.balance,
-        },
-    };
 }

--- a/lib/services/pool/pool-types.ts
+++ b/lib/services/pool/pool-types.ts
@@ -17,7 +17,7 @@ import { SwapV2 } from '@balancer-labs/sor';
 export interface PoolService {
     updatePool(pool: GqlPoolUnion): void;
 
-    joinGetProportionalSuggestion?(
+    joinGetMaxProportionalForUserBalances?(
         userInvestTokenBalances: TokenAmountHumanReadable[],
     ): Promise<TokenAmountHumanReadable[]>;
     joinGetProportionalSuggestionForFixedAmount?(

--- a/lib/services/pool/pool-types.ts
+++ b/lib/services/pool/pool-types.ts
@@ -17,6 +17,9 @@ import { SwapV2 } from '@balancer-labs/sor';
 export interface PoolService {
     updatePool(pool: GqlPoolUnion): void;
 
+    joinGetProportionalSuggestion?(
+        userInvestTokenBalances: TokenAmountHumanReadable[],
+    ): Promise<TokenAmountHumanReadable[]>;
     joinGetProportionalSuggestionForFixedAmount?(
         fixedAmount: TokenAmountHumanReadable,
         tokensIn: string[],

--- a/lib/services/pool/pool-weighted-boosted.service.ts
+++ b/lib/services/pool/pool-weighted-boosted.service.ts
@@ -116,7 +116,7 @@ export class PoolWeightedBoostedService implements PoolService {
         };
     }
 
-    public async joinGetProportionalSuggestion(userInvestTokenBalances: TokenAmountHumanReadable[]) {
+    public async joinGetMaxProportionalForUserBalances(userInvestTokenBalances: TokenAmountHumanReadable[]) {
         const fixedAmount = await this.proportionalInvestService.getProportionalSuggestion(userInvestTokenBalances);
 
         const result = await this.joinGetProportionalSuggestionForFixedAmount(

--- a/lib/services/pool/pool-weighted-v2.service.ts
+++ b/lib/services/pool/pool-weighted-v2.service.ts
@@ -73,9 +73,7 @@ export class PoolWeightedV2Service implements PoolService {
                                 ) *
                                 (1 / nestedToken.priceRate),
                         ),
-                    )
-                        .toFixed(smallestNestedBptOutAmountArray[0].token.decimals)
-                        .toString();
+                    ).toFixed(smallestNestedBptOutAmountArray[0].token.decimals);
 
                     return {
                         bptOut: calculateBptOut(this.pool.dynamicData.totalShares, amount, token.balance),

--- a/lib/services/pool/pool-weighted-v2.service.ts
+++ b/lib/services/pool/pool-weighted-v2.service.ts
@@ -44,7 +44,7 @@ export class PoolWeightedV2Service implements PoolService {
         this.composableJoinService.updatePool(pool);
     }
 
-    public async joinGetProportionalSuggestion(userInvestTokenBalances: TokenAmountHumanReadable[]) {
+    public async joinGetMaxProportionalForUserBalances(userInvestTokenBalances: TokenAmountHumanReadable[]) {
         const fixedAmount = await this.proportionalInvestService.getProportionalSuggestion(userInvestTokenBalances);
 
         const result = await this.joinGetProportionalSuggestionForFixedAmount(

--- a/lib/services/pool/pool-weighted.service.ts
+++ b/lib/services/pool/pool-weighted.service.ts
@@ -32,15 +32,20 @@ import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { PoolBaseService } from '~/lib/services/pool/lib/pool-base.service';
 import OldBigNumber from 'bignumber.js';
 import { BatchRelayerService } from '~/lib/services/batch-relayer/batch-relayer.service';
+import { PoolProportionalInvestService } from './lib/pool-proportional-invest.service';
+import { replaceEthWithWeth } from '../token/token-util';
 
 export class PoolWeightedService implements PoolService {
     private baseService: PoolBaseService;
+    private readonly proportionalInvestService: PoolProportionalInvestService;
+
     constructor(
         private pool: GqlPoolWeighted,
         private batchRelayerService: BatchRelayerService,
         private readonly wethAddress: string,
     ) {
         this.baseService = new PoolBaseService(pool, wethAddress);
+        this.proportionalInvestService = new PoolProportionalInvestService(pool);
     }
 
     public updatePool(pool: GqlPoolWeighted) {
@@ -53,6 +58,17 @@ export class PoolWeightedService implements PoolService {
         tokensIn: string[],
     ): Promise<TokenAmountHumanReadable[]> {
         return poolGetProportionalJoinAmountsForFixedAmount(fixedAmount, this.pool.tokens);
+    }
+
+    public async joinGetProportionalSuggestion(userInvestTokenBalances: TokenAmountHumanReadable[]) {
+        const fixedAmount = await this.proportionalInvestService.getProportionalSuggestion(userInvestTokenBalances);
+
+        const result = await this.joinGetProportionalSuggestionForFixedAmount(
+            fixedAmount,
+            userInvestTokenBalances.map((token) => replaceEthWithWeth(token.address)),
+        );
+
+        return result;
     }
 
     public async joinGetBptOutAndPriceImpactForTokensIn(

--- a/lib/services/pool/pool-weighted.service.ts
+++ b/lib/services/pool/pool-weighted.service.ts
@@ -60,7 +60,7 @@ export class PoolWeightedService implements PoolService {
         return poolGetProportionalJoinAmountsForFixedAmount(fixedAmount, this.pool.tokens);
     }
 
-    public async joinGetProportionalSuggestion(userInvestTokenBalances: TokenAmountHumanReadable[]) {
+    public async joinGetMaxProportionalForUserBalances(userInvestTokenBalances: TokenAmountHumanReadable[]) {
         const fixedAmount = await this.proportionalInvestService.getProportionalSuggestion(userInvestTokenBalances);
 
         const result = await this.joinGetProportionalSuggestionForFixedAmount(

--- a/modules/pool/invest/components/PoolInvestProportional.tsx
+++ b/modules/pool/invest/components/PoolInvestProportional.tsx
@@ -10,7 +10,6 @@ import {
     Text,
     VStack,
 } from '@chakra-ui/react';
-
 import { useInvestState } from '~/modules/pool/invest/lib/useInvestState';
 import { replaceEthWithWeth, replaceWethWithEth, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
 import { PoolInvestSettings } from '~/modules/pool/invest/components/PoolInvestSettings';
@@ -24,7 +23,6 @@ import { useInvest } from '~/modules/pool/invest/lib/useInvest';
 import { usePool } from '~/modules/pool/lib/usePool';
 import TokenRow from '~/components/token/TokenRow';
 import { usePoolUserTokenBalancesInWallet } from '../../lib/usePoolUserTokenBalancesInWallet';
-import { bnum } from '@balancer-labs/sor';
 import { GqlPoolToken } from '~/apollo/generated/graphql-codegen-generated';
 import { tokenInputTruncateDecimalPlaces } from '~/lib/util/input-util';
 import { PoolInvestPriceImpact } from '~/modules/pool/invest/components/PoolInvestPriceImpact';
@@ -38,7 +36,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
     const investOptions = pool.investConfig.options;
     const { setSelectedOption, selectedOptions, setInputAmounts, inputAmounts } = useInvestState();
     const { tokenProportionalAmounts } = usePoolJoinGetProportionalInvestmentAmount();
-    const { selectedInvestTokens, userInvestTokenBalances, isInvestingWithEth } = useInvest();
+    const { selectedInvestTokens, isInvestingWithEth } = useInvest();
 
     const { userPoolTokenBalances } = usePoolUserTokenBalancesInWallet();
 
@@ -68,17 +66,9 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
         }
     }
 
-    const exceedsTokenBalances = userInvestTokenBalances.some((tokenBalance) => {
-        if (!inputAmounts[tokenBalance.address] || !tokenBalance.amount) return false;
-        return bnum(inputAmounts[tokenBalance.address]).gt(tokenBalance.amount);
-    });
-
     const firstToken = selectedInvestTokens[0];
     const proportionalPercent =
-        !exceedsTokenBalances &&
-        tokenProportionalAmounts &&
-        tokenProportionalAmounts[firstToken.address] &&
-        inputAmounts[firstToken.address]
+        tokenProportionalAmounts && tokenProportionalAmounts[firstToken.address] && inputAmounts[firstToken.address]
             ? Math.round(
                   (parseFloat(inputAmounts[firstToken.address]) /
                       parseFloat(tokenProportionalAmounts[firstToken.address])) *
@@ -171,7 +161,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
                     width="full"
                     mt="8"
                     onClick={onShowPreview}
-                    isDisabled={exceedsTokenBalances || proportionalPercent === 0}
+                    isDisabled={proportionalPercent === 0}
                 >
                     Preview
                 </Button>

--- a/modules/pool/invest/components/PoolInvestProportional.tsx
+++ b/modules/pool/invest/components/PoolInvestProportional.tsx
@@ -86,9 +86,7 @@ export function PoolInvestProportional({ onShowPreview }: Props) {
                         focusThumbOnChange={false}
                         value={proportionalPercent}
                         onChange={(value) => {
-                            if (value === 100) {
-                                setInputAmounts(tokenProportionalAmounts || {});
-                            } else if (value === 0) {
+                            if (value === 0) {
                                 setInputAmounts({});
                             } else {
                                 const inputAmounts = mapValues(tokenProportionalAmounts || {}, (maxAmount, address) => {

--- a/modules/pool/invest/components/PoolInvestTypeChoice.tsx
+++ b/modules/pool/invest/components/PoolInvestTypeChoice.tsx
@@ -1,34 +1,13 @@
 import React, { useMemo } from 'react';
-import {
-    Alert,
-    Box,
-    Button,
-    Flex,
-    Grid,
-    GridItem,
-    HStack,
-    Skeleton,
-    Text,
-    AlertIcon,
-    VStack,
-    Heading,
-    Tooltip,
-    StackDivider,
-    Link,
-    useBreakpointValue,
-} from '@chakra-ui/react';
-import { ExternalLink, Grid as GridIcon } from 'react-feather';
+import { Box, Button, HStack, Text, VStack, Heading, StackDivider, Link, useBreakpointValue } from '@chakra-ui/react';
+import { ExternalLink } from 'react-feather';
 import { BeetsBox } from '~/components/box/BeetsBox';
 import { numberFormatUSDValue } from '~/lib/util/number-formats';
-import { tokenFormatAmount, tokenFormatAmountPrecise, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
+import { tokenFormatAmountPrecise, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
 import TokenAvatar from '~/components/token/TokenAvatar';
 import { useGetTokens } from '~/lib/global/useToken';
 import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUserTokenBalancesInWallet';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
-import { usePoolGetMaxProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount';
-import { CardRow } from '~/components/card/CardRow';
-import { PoolInvestStablePoolDescription } from '~/modules/pool/invest/components/PoolInvestStablePoolDescription';
-import { PoolInvestWeightedPoolDescription } from '~/modules/pool/invest/components/PoolInvestWeightedPoolDescription';
 import { usePool } from '~/modules/pool/lib/usePool';
 import Scales from '~/assets/icons/scales.svg';
 import BeetsThinking from '~/assets/icons/beetx-thinking.svg';
@@ -36,28 +15,30 @@ import BeetSmart from '~/assets/icons/beetx-smarts.svg';
 import Image from 'next/image';
 import { etherscanGetTokenUrl } from '~/lib/util/etherscan';
 import BeetsTooltip from '~/components/tooltip/BeetsTooltip';
+import { usePoolJoinGetProportionalInvestmentAmount } from '../lib/usePoolJoinGetProportionalInvestmentAmount';
 interface Props {
     onShowProportional(): void;
     onShowCustom(): void;
 }
 
 export function PoolInvestTypeChoice({ onShowProportional, onShowCustom }: Props) {
-    const { pool, poolService, isStablePool } = usePool();
-    const { priceForAmount, formattedPrice } = useGetTokens();
+    const { pool, poolService } = usePool();
+    const { formattedPrice } = useGetTokens();
     const { userPoolTokenBalances, investableAmount } = usePoolUserTokenBalancesInWallet();
     const { canInvestProportionally } = useInvest();
     const isMobile = useBreakpointValue({ base: true, md: false });
-    const { data, isLoading } = usePoolGetMaxProportionalInvestmentAmount();
+    const { totalValueProportionalAmounts } = usePoolJoinGetProportionalInvestmentAmount();
     const proportionalSupported =
         poolService.joinGetProportionalSuggestionForFixedAmount && pool.investConfig.proportionalEnabled;
 
-    const _canInvestProportionally = (data?.maxAmount || 0) > 0 && canInvestProportionally && proportionalSupported;
+    const _canInvestProportionally =
+        (totalValueProportionalAmounts || 0) > 0 && canInvestProportionally && proportionalSupported;
 
     const disabledProportionalInvestmentTooltip = useMemo(() => {
         if (!proportionalSupported) {
             return 'This pool does not support proportional investment.';
         }
-        if ((data?.maxAmount || 0) <= 0) {
+        if ((totalValueProportionalAmounts || 0) <= 0) {
             return "You don't have the appropriate funds for a proportional investment. Refer below to the tokens you need to make a proportional investment.";
         }
         return 'This pool does not support proportional investment.';
@@ -105,7 +86,9 @@ export function PoolInvestTypeChoice({ onShowProportional, onShowCustom }: Props
                                 <VStack spacing="1">
                                     <Image src={Scales} height="48" alt="beets-balanced" />
 
-                                    <Text fontSize="lg">{numberFormatUSDValue(data?.maxAmount || 0)}</Text>
+                                    <Text fontSize="lg">
+                                        {numberFormatUSDValue(totalValueProportionalAmounts || 0)}
+                                    </Text>
                                     <Text fontSize="sm">Proportional investment</Text>
                                     <Text fontSize="xs" color="beets.green">
                                         Recommended

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -28,13 +28,15 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
             //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
             const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
 
+            const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
+            const weightedValue = parseFloat(poolToken?.weight || '1') * totalUserInvestTokenBalancesValue;
+
             return {
                 ...balance,
                 //this has precision errors, but its only used for sorting, not any operations
                 normalizedAmount: poolToken?.weight
                     ? //? scaledBalance / parseFloat(poolToken.balance) / parseFloat(poolToken.weight)
-                      priceForAmount({ address: balance.address, amount: scaledBalance.toString() }) -
-                      parseFloat(poolToken.weight) * totalUserInvestTokenBalancesValue
+                      (tokenValue - weightedValue) / weightedValue
                     : scaledBalance,
             };
         }),

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -26,26 +26,25 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
             if (token.__typename === 'GqlPoolTokenPhantomStable') {
                 // another loop to find the smallest bptOut amount for the nested stable pool
                 const nestedTokens = token.pool.tokens.map((poolToken) => {
-                    const tokenAddress =
+                    const address =
                         poolToken.__typename === 'GqlPoolTokenLinear' &&
                         poolToken.pool.tokens.find((nestedPoolToken) =>
                             userInvestTokenBalanceAddresses.includes(nestedPoolToken.address),
                         )?.address;
 
-                    const amountIn =
-                        userInvestTokenBalances.find((balance) => balance.address === tokenAddress)?.amount || '';
+                    const amount = userInvestTokenBalances.find((balance) => balance.address === address)?.amount || '';
 
                     return {
-                        address: tokenAddress,
-                        amount: amountIn,
-                        bptOut: calculateBptOut(token.pool.totalShares, amountIn, poolToken.balance),
+                        address,
+                        amount,
+                        bptOut: calculateBptOut(token.pool.totalShares, amount, poolToken.balance),
                         weight: parseFloat(poolToken.totalBalance) / parseFloat(token.pool.totalShares),
                     };
                 });
                 const smallestNestedBptOutAmountArray = sortBy(nestedTokens, 'bptOut');
 
                 // calculate the proportional amounts and sum them to get the 'amountIn' for the nested stable pool bptOut calculation
-                const amountIn = sum(
+                const amount = sum(
                     smallestNestedBptOutAmountArray.map(
                         (nestedToken) =>
                             parseFloat(nestedToken.amount) *
@@ -53,31 +52,30 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
                     ),
                 ).toString();
 
-                const bptOut = calculateBptOut(pool.dynamicData.totalShares, amountIn, token.balance);
+                const bptOut = calculateBptOut(pool.dynamicData.totalShares, amount, token.balance);
 
                 return {
                     bptOut,
                     token: {
                         address: smallestNestedBptOutAmountArray[0].address,
-                        amount: amountIn.toString(),
+                        amount: amount.toString(),
                     },
                 };
             } else {
-                const tokenAddress =
+                const address =
                     token.__typename === 'GqlPoolTokenLinear'
                         ? token.pool.tokens.find((poolToken) =>
                               userInvestTokenBalanceAddresses.includes(poolToken.address),
                           )?.address
                         : token.address;
 
-                const amountIn =
-                    userInvestTokenBalances.find((balance) => balance.address === tokenAddress)?.amount || '';
+                const amount = userInvestTokenBalances.find((balance) => balance.address === address)?.amount || '';
 
                 return {
-                    bptOut: calculateBptOut(pool.dynamicData.totalShares, amountIn, token.balance),
+                    bptOut: calculateBptOut(pool.dynamicData.totalShares, amount, token.balance),
                     token: {
-                        address: tokenAddress,
-                        amount: amountIn,
+                        address,
+                        amount,
                     },
                 };
             }

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -23,11 +23,11 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
         async ({ queryKey }) => {
             const hasEth = !!userInvestTokenBalances.find((token) => isEth(token.address));
 
-            if (!poolService.joinGetProportionalSuggestion) {
+            if (!poolService.joinGetMaxProportionalForUserBalances) {
                 return {};
             }
 
-            const result = await poolService.joinGetProportionalSuggestion(userInvestTokenBalances);
+            const result = await poolService.joinGetMaxProportionalForUserBalances(userInvestTokenBalances);
 
             return {
                 tokenProportionalAmounts: Object.fromEntries(

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -68,8 +68,6 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
                 selectedInvestTokens.map((token) => replaceEthWithWeth(token.address)),
             );
 
-            console.log({ result });
-
             return Object.fromEntries(
                 result.map((item) => [hasEth ? replaceWethWithEth(item.address) : item.address, item.amount]),
             );

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -13,118 +13,171 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
     const { userAddress } = useUserAccount();
     const { priceForAmount } = useGetTokens();
 
-    const userInvestTokenBalancesWithoutPhantomStable: TokenAmountHumanReadable[] = [];
-    const userInvestTokenBalancesPhantomStableOnly: TokenAmountHumanReadable[] = [];
+    // const userInvestTokenBalancesWithoutPhantomStable: TokenAmountHumanReadable[] = [];
+    // const userInvestTokenBalancesPhantomStableOnly: TokenAmountHumanReadable[] = [];
 
-    const phantomStableIndex = pool.tokens.find((token) => token.__typename === 'GqlPoolTokenPhantomStable')?.index;
+    // const phantomStableIndex = pool.tokens
+    //     .filter((token) => token.__typename === 'GqlPoolTokenPhantomStable')
+    //     .map((token) => token.index);
+    // userInvestTokenBalances.forEach((balance) => {
+    //     const options = pool.investConfig.options.filter(
+    //         (option) => !phantomStableIndex.includes(option.poolTokenIndex),
+    //     );
+    //     const hasBalanceToken = options.find((option) =>
+    //         option.tokenOptions.find((tokenOption) => tokenOption.address === balance.address),
+    //     );
+    //     hasBalanceToken
+    //         ? userInvestTokenBalancesWithoutPhantomStable.push(balance)
+    //         : userInvestTokenBalancesPhantomStableOnly.push(balance);
+    // });
+
+    // const totalUserInvestTokenBalancesValueWithoutPhantomStable = sumBy(
+    //     userInvestTokenBalancesWithoutPhantomStable,
+    //     priceForAmount,
+    // );
+
+    // const totalUserInvestTokenBalancesValuePhantomStableOnly = sumBy(
+    //     userInvestTokenBalancesPhantomStableOnly,
+    //     priceForAmount,
+    // );
+
+    // function getSmallestValue(balances: any[], totalUserInvestTokenBalancesValue: any) {
+    //     return balances.map((balance) => {
+    //         const investOption = pool.investConfig.options.find((option) => {
+    //             const tokenOption = option.tokenOptions.find(
+    //                 (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
+    //             );
+
+    //             return !!tokenOption;
+    //         });
+
+    //         const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
+    //         //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
+    //         //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
+    //         const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
+
+    //         const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
+    //         const poolData =
+    //             phantomStableIndex.length > 0
+    //                 ? pool.tokens.filter((token) => phantomStableIndex.includes(token.index))[0]
+    //                 : pool;
+    //         const totalLiquidity = 'pool' in poolData ? poolData.pool.totalLiquidity : pool.dynamicData.totalLiquidity;
+    //         const stablePhantomAmount =
+    //             'pool' in poolData
+    //                 ? poolData.pool.tokens
+    //                       .filter((token) =>
+    //                           'pool' in token
+    //                               ? token.pool.tokens.find((nestedToken) => nestedToken.address === balance.address)
+    //                               : null,
+    //                       )
+    //                       .flat()[0]
+    //                 : null;
+
+    //         const amount = stablePhantomAmount?.totalBalance ?? poolToken?.balance;
+    //         console.log(balance.address, amount, stablePhantomAmount, pool.dynamicData.totalLiquidity, totalLiquidity);
+    //         const calculatedWeight =
+    //             priceForAmount({ address: balance.address, amount: amount || '' }) / parseFloat(totalLiquidity);
+    //         const weightedValue =
+    //             (poolToken?.weight && !('pool' in poolData) ? parseFloat(poolToken?.weight || '') : calculatedWeight) *
+    //             totalUserInvestTokenBalancesValue;
+
+    //         return {
+    //             ...balance,
+    //             normalizedAmount: (tokenValue - weightedValue) / weightedValue,
+    //             calculatedWeight,
+    //         };
+    //     });
+    // }
+
+    // const phantomStableArray = getSmallestValue(
+    //     userInvestTokenBalancesPhantomStableOnly,
+    //     totalUserInvestTokenBalancesValuePhantomStableOnly,
+    // );
+
+    // console.log({
+    //     userInvestTokenBalancesPhantomStableOnly,
+    //     totalUserInvestTokenBalancesValuePhantomStableOnly,
+    //     phantomStableArray,
+    // });
+
+    // const tokenWithSmallestValue = sortBy(
+    //     userInvestTokenBalances.map((balance) => {
+    //         const investOption = pool.investConfig.options.find((option) => {
+    //             const tokenOption = option.tokenOptions.find(
+    //                 (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
+    //             );
+
+    //             return !!tokenOption;
+    //         });
+
+    //         const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
+    //         //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
+    //         //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
+    //         const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
+
+    //         const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
+    //         const calculatedWeight =
+    //             priceForAmount({ address: balance.address, amount: poolToken?.balance || '' }) /
+    //             parseFloat(pool.dynamicData.totalLiquidity);
+    //         const weightedValue =
+    //             (poolToken?.weight ? parseFloat(poolToken?.weight || '') : calculatedWeight) *
+    //             totalUserInvestTokenBalancesValueWithoutPhantomStable;
+
+    //         return {
+    //             ...balance,
+    //             normalizedAmount: (tokenValue - weightedValue) / weightedValue,
+    //         };
+    //     }),
+    //     'normalizedAmount',
+    // )[0];
+
+    const totalValueArray: any[] = [];
+    const smallestValueArray = [];
     userInvestTokenBalances.forEach((balance) => {
-        const options = pool.investConfig.options.filter((option) => option.poolTokenIndex !== phantomStableIndex);
-        const hasBalanceToken = options.find((option) =>
-            option.tokenOptions.find((tokenOption) => tokenOption.address === balance.address),
-        );
-        hasBalanceToken
-            ? userInvestTokenBalancesWithoutPhantomStable.push(balance)
-            : userInvestTokenBalancesPhantomStableOnly.push(balance);
-    });
+        const investOption = pool.investConfig.options.find((option) => {
+            const tokenOption = option.tokenOptions.find(
+                (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
+            );
 
-    const totalUserInvestTokenBalancesValueWithoutPhantomStable = sumBy(
-        userInvestTokenBalancesWithoutPhantomStable,
-        priceForAmount,
-    );
-
-    const totalUserInvestTokenBalancesValuePhantomStableOnly = sumBy(
-        userInvestTokenBalancesPhantomStableOnly,
-        priceForAmount,
-    );
-
-    function getSmallestValue(balances: any[], totalUserInvestTokenBalancesValue: any) {
-        return balances.map((balance) => {
-            const investOption = pool.investConfig.options.find((option) => {
-                const tokenOption = option.tokenOptions.find(
-                    (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
-                );
-
-                return !!tokenOption;
-            });
-
-            const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
-            //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
-            //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
-            const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
-
-            const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
-            const poolData = phantomStableIndex
-                ? pool.tokens.filter((token) => token.index === phantomStableIndex)[0]
-                : pool;
-            const totalLiquidity = 'pool' in poolData ? poolData.pool.totalLiquidity : pool.dynamicData.totalLiquidity;
-            const stablePhantomAmount =
-                'pool' in poolData
-                    ? poolData.pool.tokens
-                          .filter((token) =>
-                              'pool' in token
-                                  ? token.pool.tokens.find((nestedToken) => nestedToken.address === balance.address)
-                                  : null,
-                          )
-                          .flat()[0]
-                    : null;
-
-            const amount = stablePhantomAmount?.totalBalance ?? poolToken?.balance;
-            console.log(balance.address, amount, stablePhantomAmount, pool.dynamicData.totalLiquidity, totalLiquidity);
-            const calculatedWeight =
-                priceForAmount({ address: balance.address, amount: amount || '' }) / parseFloat(totalLiquidity);
-            const weightedValue =
-                (poolToken?.weight && !('pool' in poolData) ? parseFloat(poolToken?.weight || '') : calculatedWeight) *
-                totalUserInvestTokenBalancesValue;
-
-            return {
-                ...balance,
-                normalizedAmount: (tokenValue - weightedValue) / weightedValue,
-                calculatedWeight,
-            };
+            return !!tokenOption;
         });
-    }
 
-    const phantomStableArray = getSmallestValue(
-        userInvestTokenBalancesPhantomStableOnly,
-        totalUserInvestTokenBalancesValuePhantomStableOnly,
-    );
+        const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
 
-    console.log({
-        userInvestTokenBalancesPhantomStableOnly,
-        totalUserInvestTokenBalancesValuePhantomStableOnly,
-        phantomStableArray,
+        if (pool.__typename === 'GqlPoolWeighted') {
+            if (poolToken?.__typename === 'GqlPoolTokenPhantomStable') {
+                const totalLiquidity = poolToken.pool.totalLiquidity;
+                const totalValue = sumBy(
+                    pool.investConfig.options
+                        .map((option, index) =>
+                            option.poolTokenIndex === poolToken.index ? userInvestTokenBalances[index] : [],
+                        )
+                        .flat(),
+                    priceForAmount,
+                );
+                const token = poolToken.pool.tokens
+                    .filter((token) =>
+                        'pool' in token
+                            ? token.pool.tokens.find((nestedToken) => nestedToken.address === balance.address)
+                            : null,
+                    )
+                    .flat()[0];
+                const weight = parseFloat(token?.totalBalance || '') / parseFloat(totalLiquidity);
+                const tokenValue = weight * totalValue;
+                console.log(totalValue);
+            } else {
+                totalValueArray.push({ address: balance.address, amount: balance.amount, weight: poolToken?.weight });
+            }
+        }
     });
 
-    const tokenWithSmallestValue = sortBy(
-        userInvestTokenBalances.map((balance) => {
-            const investOption = pool.investConfig.options.find((option) => {
-                const tokenOption = option.tokenOptions.find(
-                    (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
-                );
+    console.log({ totalValueArray });
 
-                return !!tokenOption;
-            });
-
-            const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
-            //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
-            //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
-            const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
-
-            const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
-            const calculatedWeight =
-                priceForAmount({ address: balance.address, amount: poolToken?.balance || '' }) /
-                parseFloat(pool.dynamicData.totalLiquidity);
-            const weightedValue =
-                (poolToken?.weight ? parseFloat(poolToken?.weight || '') : calculatedWeight) *
-                totalUserInvestTokenBalancesValueWithoutPhantomStable;
-
-            return {
-                ...balance,
-                normalizedAmount: (tokenValue - weightedValue) / weightedValue,
-            };
-        }),
-        'normalizedAmount',
-    )[0];
+    const tokenWithSmallestValue = {
+        address: '0x94b008aa00579c1307b0ef2c499ad98a8ce58e58',
+        amount: '0.801866',
+        normalizedAmount: 0.23992669458997087,
+    };
 
     const query = useQuery(
         [

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -1,117 +1,33 @@
 import { useQuery } from 'react-query';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
-import { sortBy, sum, sumBy } from 'lodash';
-import { isEth, replaceEthWithWeth, replaceWethWithEth } from '~/lib/services/token/token-util';
+import { sumBy } from 'lodash';
+import { isEth, replaceWethWithEth } from '~/lib/services/token/token-util';
 import { useUserAccount } from '~/lib/user/useUserAccount';
 import { usePool } from '~/modules/pool/lib/usePool';
 import { useGetTokens } from '~/lib/global/useToken';
 
-function calculateBptOut(bptTotalSupply: string, amountIn: string, balance: string) {
-    return parseFloat(bptTotalSupply) * (parseFloat(amountIn || '') / parseFloat(balance));
-}
-
 export function usePoolJoinGetProportionalInvestmentAmount() {
-    const { poolService, pool } = usePool();
-    const { userInvestTokenBalances, selectedInvestTokens } = useInvest();
+    const { poolService } = usePool();
+    const { userInvestTokenBalances } = useInvest();
     const { userAddress } = useUserAccount();
     const { priceForAmount } = useGetTokens();
-
-    // store all the available token addresses in an array for linear pool lookups
-    const userInvestTokenBalanceAddresses = userInvestTokenBalances.map((balance) => balance.address);
-
-    const smallestBptOutAmount = sortBy(
-        // loop through the pool tokens to find out which token (and amount) would give the smallest bptOut amount
-        // so we can base the proportions for the other tokens on that
-        pool.tokens.map((token) => {
-            if (token.__typename === 'GqlPoolTokenPhantomStable') {
-                // another loop to find the smallest bptOut amount for the nested stable pool
-                const nestedTokens = token.pool.tokens.map((poolToken) => {
-                    const address =
-                        poolToken.__typename === 'GqlPoolTokenLinear' &&
-                        poolToken.pool.tokens.find((nestedPoolToken) =>
-                            userInvestTokenBalanceAddresses.includes(nestedPoolToken.address),
-                        )?.address;
-
-                    const amount = userInvestTokenBalances.find((balance) => balance.address === address)?.amount || '';
-
-                    return {
-                        address,
-                        amount,
-                        bptOut: calculateBptOut(token.pool.totalShares, amount, poolToken.balance),
-                        weight: parseFloat(poolToken.totalBalance) / parseFloat(token.pool.totalShares),
-                    };
-                });
-                const smallestNestedBptOutAmountArray = sortBy(nestedTokens, 'bptOut');
-
-                // calculate the proportional amounts and sum them to get the 'amountIn' for the nested stable pool bptOut calculation
-                const amount = sum(
-                    smallestNestedBptOutAmountArray.map(
-                        (nestedToken) =>
-                            parseFloat(nestedToken.amount) *
-                            (nestedToken.weight / smallestNestedBptOutAmountArray[0].weight),
-                    ),
-                ).toString();
-
-                const bptOut = calculateBptOut(pool.dynamicData.totalShares, amount, token.balance);
-
-                return {
-                    bptOut,
-                    token: {
-                        address: smallestNestedBptOutAmountArray[0].address,
-                        amount: amount.toString(),
-                    },
-                };
-            } else {
-                const address =
-                    token.__typename === 'GqlPoolTokenLinear'
-                        ? token.pool.tokens.find((poolToken) =>
-                              userInvestTokenBalanceAddresses.includes(poolToken.address),
-                          )?.address
-                        : token.address;
-
-                const amount = userInvestTokenBalances.find((balance) => balance.address === address)?.amount || '';
-
-                return {
-                    bptOut: calculateBptOut(pool.dynamicData.totalShares, amount, token.balance),
-                    token: {
-                        address,
-                        amount,
-                    },
-                };
-            }
-        }),
-        'bptOut',
-    )[0];
-
-    const tokenWithSmallestBptOutAmount = {
-        address: smallestBptOutAmount.token.address || '',
-        amount: smallestBptOutAmount.token.amount || '',
-    };
 
     const query = useQuery(
         [
             {
                 key: 'joinGetProportionalInvestmentAmount',
                 userInvestTokenBalances,
-                tokenWithSmallestBptOutAmount,
                 userAddress,
             },
         ],
         async ({ queryKey }) => {
             const hasEth = !!userInvestTokenBalances.find((token) => isEth(token.address));
-            const fixedAmount = {
-                ...tokenWithSmallestBptOutAmount,
-                address: replaceEthWithWeth(tokenWithSmallestBptOutAmount.address || ''),
-            };
 
-            if (!poolService.joinGetProportionalSuggestionForFixedAmount) {
+            if (!poolService.joinGetProportionalSuggestion) {
                 return {};
             }
 
-            const result = await poolService.joinGetProportionalSuggestionForFixedAmount(
-                fixedAmount,
-                selectedInvestTokens.map((token) => replaceEthWithWeth(token.address)),
-            );
+            const result = await poolService.joinGetProportionalSuggestion(userInvestTokenBalances);
 
             return {
                 tokenProportionalAmounts: Object.fromEntries(

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
-import { sortBy, sumBy } from 'lodash';
+import { sortBy, sum, sumBy } from 'lodash';
 import { isEth, isWeth, replaceEthWithWeth, replaceWethWithEth } from '~/lib/services/token/token-util';
 import { useUserAccount } from '~/lib/user/useUserAccount';
 import { usePool } from '~/modules/pool/lib/usePool';
@@ -13,126 +13,8 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
     const { userAddress } = useUserAccount();
     const { priceForAmount } = useGetTokens();
 
-    // const userInvestTokenBalancesWithoutPhantomStable: TokenAmountHumanReadable[] = [];
-    // const userInvestTokenBalancesPhantomStableOnly: TokenAmountHumanReadable[] = [];
-
-    // const phantomStableIndex = pool.tokens
-    //     .filter((token) => token.__typename === 'GqlPoolTokenPhantomStable')
-    //     .map((token) => token.index);
-    // userInvestTokenBalances.forEach((balance) => {
-    //     const options = pool.investConfig.options.filter(
-    //         (option) => !phantomStableIndex.includes(option.poolTokenIndex),
-    //     );
-    //     const hasBalanceToken = options.find((option) =>
-    //         option.tokenOptions.find((tokenOption) => tokenOption.address === balance.address),
-    //     );
-    //     hasBalanceToken
-    //         ? userInvestTokenBalancesWithoutPhantomStable.push(balance)
-    //         : userInvestTokenBalancesPhantomStableOnly.push(balance);
-    // });
-
-    // const totalUserInvestTokenBalancesValueWithoutPhantomStable = sumBy(
-    //     userInvestTokenBalancesWithoutPhantomStable,
-    //     priceForAmount,
-    // );
-
-    // const totalUserInvestTokenBalancesValuePhantomStableOnly = sumBy(
-    //     userInvestTokenBalancesPhantomStableOnly,
-    //     priceForAmount,
-    // );
-
-    // function getSmallestValue(balances: any[], totalUserInvestTokenBalancesValue: any) {
-    //     return balances.map((balance) => {
-    //         const investOption = pool.investConfig.options.find((option) => {
-    //             const tokenOption = option.tokenOptions.find(
-    //                 (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
-    //             );
-
-    //             return !!tokenOption;
-    //         });
-
-    //         const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
-    //         //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
-    //         //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
-    //         const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
-
-    //         const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
-    //         const poolData =
-    //             phantomStableIndex.length > 0
-    //                 ? pool.tokens.filter((token) => phantomStableIndex.includes(token.index))[0]
-    //                 : pool;
-    //         const totalLiquidity = 'pool' in poolData ? poolData.pool.totalLiquidity : pool.dynamicData.totalLiquidity;
-    //         const stablePhantomAmount =
-    //             'pool' in poolData
-    //                 ? poolData.pool.tokens
-    //                       .filter((token) =>
-    //                           'pool' in token
-    //                               ? token.pool.tokens.find((nestedToken) => nestedToken.address === balance.address)
-    //                               : null,
-    //                       )
-    //                       .flat()[0]
-    //                 : null;
-
-    //         const amount = stablePhantomAmount?.totalBalance ?? poolToken?.balance;
-    //         console.log(balance.address, amount, stablePhantomAmount, pool.dynamicData.totalLiquidity, totalLiquidity);
-    //         const calculatedWeight =
-    //             priceForAmount({ address: balance.address, amount: amount || '' }) / parseFloat(totalLiquidity);
-    //         const weightedValue =
-    //             (poolToken?.weight && !('pool' in poolData) ? parseFloat(poolToken?.weight || '') : calculatedWeight) *
-    //             totalUserInvestTokenBalancesValue;
-
-    //         return {
-    //             ...balance,
-    //             normalizedAmount: (tokenValue - weightedValue) / weightedValue,
-    //             calculatedWeight,
-    //         };
-    //     });
-    // }
-
-    // const phantomStableArray = getSmallestValue(
-    //     userInvestTokenBalancesPhantomStableOnly,
-    //     totalUserInvestTokenBalancesValuePhantomStableOnly,
-    // );
-
-    // console.log({
-    //     userInvestTokenBalancesPhantomStableOnly,
-    //     totalUserInvestTokenBalancesValuePhantomStableOnly,
-    //     phantomStableArray,
-    // });
-
-    // const tokenWithSmallestValue = sortBy(
-    //     userInvestTokenBalances.map((balance) => {
-    //         const investOption = pool.investConfig.options.find((option) => {
-    //             const tokenOption = option.tokenOptions.find(
-    //                 (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
-    //             );
-
-    //             return !!tokenOption;
-    //         });
-
-    //         const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
-    //         //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
-    //         //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
-    //         const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
-
-    //         const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
-    //         const calculatedWeight =
-    //             priceForAmount({ address: balance.address, amount: poolToken?.balance || '' }) /
-    //             parseFloat(pool.dynamicData.totalLiquidity);
-    //         const weightedValue =
-    //             (poolToken?.weight ? parseFloat(poolToken?.weight || '') : calculatedWeight) *
-    //             totalUserInvestTokenBalancesValueWithoutPhantomStable;
-
-    //         return {
-    //             ...balance,
-    //             normalizedAmount: (tokenValue - weightedValue) / weightedValue,
-    //         };
-    //     }),
-    //     'normalizedAmount',
-    // )[0];
-
     const totalValueArray: any[] = [];
-    const smallestValueArray = [];
+    const smallestValueArray: any[] = [];
     userInvestTokenBalances.forEach((balance) => {
         const investOption = pool.investConfig.options.find((option) => {
             const tokenOption = option.tokenOptions.find(
@@ -155,6 +37,7 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
                         .flat(),
                     priceForAmount,
                 );
+
                 const token = poolToken.pool.tokens
                     .filter((token) =>
                         'pool' in token
@@ -162,22 +45,84 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
                             : null,
                     )
                     .flat()[0];
-                const weight = parseFloat(token?.totalBalance || '') / parseFloat(totalLiquidity);
-                const tokenValue = weight * totalValue;
-                console.log(totalValue);
+                const weight =
+                    priceForAmount({ address: token.address, amount: token?.totalBalance }) /
+                    parseFloat(totalLiquidity);
+                const weightedValue = weight * totalValue;
+                const tokenValue = priceForAmount(balance);
+                smallestValueArray.push({
+                    ...balance,
+                    poolIndex: poolToken.index,
+                    ratioDiff: (tokenValue / weightedValue) * tokenValue,
+                    weight,
+                });
+                totalValueArray.push({ poolIndex: poolToken?.index, amount: weightedValue, weight: poolToken?.weight });
             } else {
-                totalValueArray.push({ address: balance.address, amount: balance.amount, weight: poolToken?.weight });
+                totalValueArray.push({
+                    poolIndex: poolToken?.index,
+                    address: balance.address,
+                    amount: balance.amount,
+                    weight: poolToken?.weight,
+                });
             }
         }
     });
 
-    console.log({ totalValueArray });
+    const totalValue = sum(
+        pool.tokens.map((token) => {
+            const values = totalValueArray.filter((item) => item.poolIndex === token.index);
+            if (values.length === 1) {
+                return priceForAmount({ address: values[0].address, amount: values[0].amount });
+            } else {
+                return sum(values.map((value) => value.amount));
+            }
+        }),
+    );
 
-    const tokenWithSmallestValue = {
-        address: '0x94b008aa00579c1307b0ef2c499ad98a8ce58e58',
-        amount: '0.801866',
-        normalizedAmount: 0.23992669458997087,
-    };
+    totalValueArray.forEach((item) => {
+        if ('address' in item) {
+            const tokenValue = priceForAmount({ address: item.address, amount: item.amount });
+            const weightedValue = item.weight * totalValue;
+            smallestValueArray.push({
+                address: item.address,
+                amount: item.amount,
+                poolIndex: item.poolIndex,
+                ratioDiff: (tokenValue / weightedValue) * tokenValue,
+            });
+        }
+    });
+
+    const phantomStableIndices = pool.tokens
+        .filter((token) => token.__typename === 'GqlPoolTokenPhantomStable')
+        .map((token) => token.index);
+
+    if (phantomStableIndices.length > 0) {
+        phantomStableIndices.forEach((idx) => {
+            const filteredSmallestValueArray = smallestValueArray.filter((item) => item.poolIndex === idx);
+            const psSmallestValue = sortBy(filteredSmallestValueArray, 'ratioDiff')[0];
+
+            const totalValue =
+                sum(
+                    filteredSmallestValueArray
+                        .filter((item) => item.address !== psSmallestValue.address)
+                        .map(
+                            (item) => parseFloat(item.amount) * (1 / parseFloat(psSmallestValue.weight)) * item.weight,
+                        ),
+                ) + parseFloat(psSmallestValue.amount);
+            const updatedArray = filteredSmallestValueArray.map((item) => ({
+                ...item,
+                amount: totalValue.toString(),
+            }));
+            smallestValueArray.forEach((item, index) => {
+                const [update] = updatedArray.filter((update) => update.address === item.address);
+                if (update) {
+                    smallestValueArray[index] = update;
+                }
+            });
+        });
+    }
+
+    const tokenWithSmallestValue = sortBy(smallestValueArray, 'ratioDiff')[0];
 
     const query = useQuery(
         [

--- a/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
+++ b/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount.ts
@@ -1,11 +1,14 @@
 import { useQuery } from 'react-query';
 import { useInvest } from '~/modules/pool/invest/lib/useInvest';
 import { sortBy, sum, sumBy } from 'lodash';
-import { isEth, isWeth, replaceEthWithWeth, replaceWethWithEth } from '~/lib/services/token/token-util';
+import { isEth, replaceEthWithWeth, replaceWethWithEth } from '~/lib/services/token/token-util';
 import { useUserAccount } from '~/lib/user/useUserAccount';
 import { usePool } from '~/modules/pool/lib/usePool';
 import { useGetTokens } from '~/lib/global/useToken';
-import { TokenAmountHumanReadable } from '~/lib/services/token/token-types';
+
+function calculateBptOut(bptTotalSupply: string, aI: string, b: string) {
+    return parseFloat(bptTotalSupply) * (parseFloat(aI || '') / parseFloat(b));
+}
 
 export function usePoolJoinGetProportionalInvestmentAmount() {
     const { poolService, pool } = usePool();
@@ -13,116 +16,79 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
     const { userAddress } = useUserAccount();
     const { priceForAmount } = useGetTokens();
 
-    const totalValueArray: any[] = [];
-    const smallestValueArray: any[] = [];
-    userInvestTokenBalances.forEach((balance) => {
-        const investOption = pool.investConfig.options.find((option) => {
-            const tokenOption = option.tokenOptions.find(
-                (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
-            );
-
-            return !!tokenOption;
-        });
-
-        const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
-
-        if (pool.__typename === 'GqlPoolWeighted') {
-            if (poolToken?.__typename === 'GqlPoolTokenPhantomStable') {
-                const totalLiquidity = poolToken.pool.totalLiquidity;
-                const totalValue = sumBy(
-                    pool.investConfig.options
-                        .map((option, index) =>
-                            option.poolTokenIndex === poolToken.index ? userInvestTokenBalances[index] : [],
-                        )
-                        .flat(),
-                    priceForAmount,
-                );
-
-                const token = poolToken.pool.tokens
-                    .filter((token) =>
-                        'pool' in token
-                            ? token.pool.tokens.find((nestedToken) => nestedToken.address === balance.address)
-                            : null,
-                    )
-                    .flat()[0];
-                const weight =
-                    priceForAmount({ address: token.address, amount: token?.totalBalance }) /
-                    parseFloat(totalLiquidity);
-                const weightedValue = weight * totalValue;
-                const tokenValue = priceForAmount(balance);
-                smallestValueArray.push({
-                    ...balance,
-                    poolIndex: poolToken.index,
-                    ratioDiff: (tokenValue / weightedValue) * tokenValue,
-                    weight,
-                });
-                totalValueArray.push({ poolIndex: poolToken?.index, amount: weightedValue, weight: poolToken?.weight });
-            } else {
-                totalValueArray.push({
-                    poolIndex: poolToken?.index,
-                    address: balance.address,
-                    amount: balance.amount,
-                    weight: poolToken?.weight,
-                });
-            }
-        }
-    });
-
-    const totalValue = sum(
+    const smallestValue = sortBy(
         pool.tokens.map((token) => {
-            const values = totalValueArray.filter((item) => item.poolIndex === token.index);
-            if (values.length === 1) {
-                return priceForAmount({ address: values[0].address, amount: values[0].amount });
+            const userInvestTokenBalanceAddresses = userInvestTokenBalances.map((balance) => balance.address);
+
+            const bptTotalSupply =
+                token.__typename === 'GqlPoolTokenPhantomStable'
+                    ? token.pool.totalShares
+                    : pool.dynamicData.totalShares;
+            const b = token.balance;
+
+            if (token.__typename === 'GqlPoolTokenPhantomStable') {
+                const nestedTokens = token.pool.tokens.map((poolToken) => {
+                    const tokenAddress =
+                        poolToken.__typename === 'GqlPoolTokenLinear' &&
+                        poolToken.pool.tokens.find((nestedPoolToken) =>
+                            userInvestTokenBalanceAddresses.includes(nestedPoolToken.address),
+                        )?.address;
+                    const b = poolToken.balance;
+                    const aI =
+                        userInvestTokenBalances.find((balance) => balance.address === tokenAddress)?.amount || '';
+                    const bptOut = calculateBptOut(bptTotalSupply, aI, b);
+                    return { address: tokenAddress, amount: aI, bptOut };
+                });
+                const smallestValueTokenArray = sortBy(nestedTokens, 'bptOut');
+                const smallestValueToken = smallestValueTokenArray[0];
+
+                const aI = smallestValueToken.bptOut.toString();
+                const bptOut = calculateBptOut(pool.dynamicData.totalShares, aI, b);
+
+                const totalValue =
+                    sum(
+                        smallestValueTokenArray
+                            .slice(1)
+                            .map(
+                                (nestedToken) =>
+                                    (1 / (nestedToken.bptOut / smallestValueToken.bptOut)) *
+                                    parseFloat(nestedToken.amount || ''),
+                            ),
+                    ) + parseFloat(smallestValueToken.amount || '');
+
+                return {
+                    bptOut,
+                    smallest: {
+                        ...smallestValueToken,
+                        amount: totalValue.toString(),
+                    },
+                };
             } else {
-                return sum(values.map((value) => value.amount));
+                const tokenAddress =
+                    token.__typename === 'GqlPoolTokenLinear'
+                        ? token.pool.tokens.find((poolToken) =>
+                              userInvestTokenBalanceAddresses.includes(poolToken.address),
+                          )?.address
+                        : token.address;
+                const aI = userInvestTokenBalances.find((balance) => balance.address === tokenAddress)?.amount || '';
+                const bptOut = calculateBptOut(bptTotalSupply, aI, b);
+
+                return {
+                    bptOut,
+                    smallest: {
+                        address: tokenAddress,
+                        amount: aI,
+                    },
+                };
             }
         }),
-    );
+        'bptOut',
+    )[0];
 
-    totalValueArray.forEach((item) => {
-        if ('address' in item) {
-            const tokenValue = priceForAmount({ address: item.address, amount: item.amount });
-            const weightedValue = item.weight * totalValue;
-            smallestValueArray.push({
-                address: item.address,
-                amount: item.amount,
-                poolIndex: item.poolIndex,
-                ratioDiff: (tokenValue / weightedValue) * tokenValue,
-            });
-        }
-    });
-
-    const phantomStableIndices = pool.tokens
-        .filter((token) => token.__typename === 'GqlPoolTokenPhantomStable')
-        .map((token) => token.index);
-
-    if (phantomStableIndices.length > 0) {
-        phantomStableIndices.forEach((idx) => {
-            const filteredSmallestValueArray = smallestValueArray.filter((item) => item.poolIndex === idx);
-            const psSmallestValue = sortBy(filteredSmallestValueArray, 'ratioDiff')[0];
-
-            const totalValue =
-                sum(
-                    filteredSmallestValueArray
-                        .filter((item) => item.address !== psSmallestValue.address)
-                        .map(
-                            (item) => parseFloat(item.amount) * (1 / parseFloat(psSmallestValue.weight)) * item.weight,
-                        ),
-                ) + parseFloat(psSmallestValue.amount);
-            const updatedArray = filteredSmallestValueArray.map((item) => ({
-                ...item,
-                amount: totalValue.toString(),
-            }));
-            smallestValueArray.forEach((item, index) => {
-                const [update] = updatedArray.filter((update) => update.address === item.address);
-                if (update) {
-                    smallestValueArray[index] = update;
-                }
-            });
-        });
-    }
-
-    const tokenWithSmallestValue = sortBy(smallestValueArray, 'ratioDiff')[0];
+    const tokenWithSmallestValue = {
+        address: smallestValue.smallest.address || '',
+        amount: smallestValue.smallest.amount || '',
+    };
 
     const query = useQuery(
         [
@@ -137,7 +103,7 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
             const hasEth = !!userInvestTokenBalances.find((token) => isEth(token.address));
             const fixedAmount = {
                 ...tokenWithSmallestValue,
-                address: replaceEthWithWeth(tokenWithSmallestValue.address),
+                address: replaceEthWithWeth(tokenWithSmallestValue.address || ''),
             };
 
             if (!poolService.joinGetProportionalSuggestionForFixedAmount) {
@@ -153,7 +119,6 @@ export function usePoolJoinGetProportionalInvestmentAmount() {
                 tokenProportionalAmounts: Object.fromEntries(
                     result.map((item) => [hasEth ? replaceWethWithEth(item.address) : item.address, item.amount]),
                 ),
-                // this is still not ideal for when there are multiple invest options for a token
                 totalValueProportionalAmounts: sumBy(result, priceForAmount),
             };
         },

--- a/modules/reliquary/invest/components/ReliquaryInvestProportional.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestProportional.tsx
@@ -10,7 +10,6 @@ import {
     Text,
     VStack,
 } from '@chakra-ui/react';
-
 import { useReliquaryInvestState } from '~/modules/reliquary/invest/lib/useReliquaryInvestState';
 import { replaceEthWithWeth, replaceWethWithEth, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
 import { ReliquaryInvestSettings } from '~/modules/reliquary/invest/components/ReliquaryInvestSettings';
@@ -23,7 +22,6 @@ import { useReliquaryInvest } from '~/modules/reliquary/invest/lib/useReliquaryI
 import { usePool } from '~/modules/pool/lib/usePool';
 import TokenRow from '~/components/token/TokenRow';
 import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUserTokenBalancesInWallet';
-import { bnum } from '@balancer-labs/sor';
 import { GqlPoolToken } from '~/apollo/generated/graphql-codegen-generated';
 import { tokenInputTruncateDecimalPlaces } from '~/lib/util/input-util';
 import { useReliquaryJoinGetProportionalInvestmentAmount } from '../lib/useReliquaryJoinGetProportionalInvestmentAmount';
@@ -37,7 +35,7 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
     const investOptions = pool.investConfig.options;
     const { setSelectedOption, selectedOptions, setInputAmounts, inputAmounts } = useReliquaryInvestState();
     const { tokenProportionalAmounts } = useReliquaryJoinGetProportionalInvestmentAmount();
-    const { selectedInvestTokens, userInvestTokenBalances, isInvestingWithEth } = useReliquaryInvest();
+    const { selectedInvestTokens, isInvestingWithEth } = useReliquaryInvest();
 
     const { userPoolTokenBalances } = usePoolUserTokenBalancesInWallet();
 
@@ -67,17 +65,9 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
         }
     }
 
-    const exceedsTokenBalances = userInvestTokenBalances.some((tokenBalance) => {
-        if (!inputAmounts[tokenBalance.address] || !tokenBalance.amount) return false;
-        return bnum(inputAmounts[tokenBalance.address]).gt(tokenBalance.amount);
-    });
-
     const firstToken = selectedInvestTokens[0];
     const proportionalPercent =
-        !exceedsTokenBalances &&
-        tokenProportionalAmounts &&
-        tokenProportionalAmounts[firstToken.address] &&
-        inputAmounts[firstToken.address]
+        tokenProportionalAmounts && tokenProportionalAmounts[firstToken.address] && inputAmounts[firstToken.address]
             ? Math.round(
                   (parseFloat(inputAmounts[firstToken.address]) /
                       parseFloat(tokenProportionalAmounts[firstToken.address])) *
@@ -169,7 +159,7 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
                     width="full"
                     mt="8"
                     onClick={onShowPreview}
-                    isDisabled={exceedsTokenBalances || proportionalPercent === 0}
+                    isDisabled={proportionalPercent === 0}
                 >
                     Preview
                 </Button>

--- a/modules/reliquary/invest/components/ReliquaryInvestProportional.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestProportional.tsx
@@ -36,7 +36,7 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
     const { pool, poolService } = usePool();
     const investOptions = pool.investConfig.options;
     const { setSelectedOption, selectedOptions, setInputAmounts, inputAmounts } = useReliquaryInvestState();
-    const { data } = useReliquaryJoinGetProportionalInvestmentAmount();
+    const { tokenProportionalAmounts } = useReliquaryJoinGetProportionalInvestmentAmount();
     const { selectedInvestTokens, userInvestTokenBalances, isInvestingWithEth } = useReliquaryInvest();
 
     const { userPoolTokenBalances } = usePoolUserTokenBalancesInWallet();
@@ -74,8 +74,15 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
 
     const firstToken = selectedInvestTokens[0];
     const proportionalPercent =
-        !exceedsTokenBalances && data && data[firstToken.address] && inputAmounts[firstToken.address]
-            ? Math.round((parseFloat(inputAmounts[firstToken.address]) / parseFloat(data[firstToken.address])) * 100)
+        !exceedsTokenBalances &&
+        tokenProportionalAmounts &&
+        tokenProportionalAmounts[firstToken.address] &&
+        inputAmounts[firstToken.address]
+            ? Math.round(
+                  (parseFloat(inputAmounts[firstToken.address]) /
+                      parseFloat(tokenProportionalAmounts[firstToken.address])) *
+                      100,
+              )
             : 0;
 
     return (
@@ -89,11 +96,11 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
                         value={proportionalPercent}
                         onChange={(value) => {
                             if (value === 100) {
-                                setInputAmounts(data || {});
+                                setInputAmounts(tokenProportionalAmounts || {});
                             } else if (value === 0) {
                                 setInputAmounts({});
                             } else {
-                                const inputAmounts = mapValues(data || {}, (maxAmount, address) => {
+                                const inputAmounts = mapValues(tokenProportionalAmounts || {}, (maxAmount, address) => {
                                     const tokenDecimals =
                                         selectedInvestTokens.find((token) => token.address === address)?.decimals || 18;
 

--- a/modules/reliquary/invest/components/ReliquaryInvestProportional.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestProportional.tsx
@@ -17,7 +17,6 @@ import { ReliquaryInvestSettings } from '~/modules/reliquary/invest/components/R
 import { BeetsBox } from '~/components/box/BeetsBox';
 import { ReliquaryInvestSummary } from '~/modules/reliquary/invest/components/ReliquaryInvestSummary';
 import React from 'react';
-import { usePoolJoinGetProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolJoinGetProportionalInvestmentAmount';
 import { keyBy, mapValues } from 'lodash';
 import { oldBnumScale, oldBnumToHumanReadable } from '~/lib/services/pool/lib/old-big-number';
 import { useReliquaryInvest } from '~/modules/reliquary/invest/lib/useReliquaryInvest';
@@ -27,6 +26,7 @@ import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUser
 import { bnum } from '@balancer-labs/sor';
 import { GqlPoolToken } from '~/apollo/generated/graphql-codegen-generated';
 import { tokenInputTruncateDecimalPlaces } from '~/lib/util/input-util';
+import { useReliquaryJoinGetProportionalInvestmentAmount } from '../lib/useReliquaryJoinGetProportionalInvestmentAmount';
 
 interface Props {
     onShowPreview(): void;
@@ -36,7 +36,7 @@ export function ReliquaryInvestProportional({ onShowPreview }: Props) {
     const { pool, poolService } = usePool();
     const investOptions = pool.investConfig.options;
     const { setSelectedOption, selectedOptions, setInputAmounts, inputAmounts } = useReliquaryInvestState();
-    const { data } = usePoolJoinGetProportionalInvestmentAmount();
+    const { data } = useReliquaryJoinGetProportionalInvestmentAmount();
     const { selectedInvestTokens, userInvestTokenBalances, isInvestingWithEth } = useReliquaryInvest();
 
     const { userPoolTokenBalances } = usePoolUserTokenBalancesInWallet();

--- a/modules/reliquary/invest/components/ReliquaryInvestTypeChoice.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestTypeChoice.tsx
@@ -1,34 +1,12 @@
 import React, { useMemo } from 'react';
-import {
-    Alert,
-    Box,
-    Button,
-    Flex,
-    Grid,
-    GridItem,
-    HStack,
-    Skeleton,
-    Text,
-    AlertIcon,
-    VStack,
-    Heading,
-    Tooltip,
-    StackDivider,
-    Link,
-    useBreakpointValue,
-} from '@chakra-ui/react';
-import { ExternalLink, Grid as GridIcon } from 'react-feather';
+import { Box, Button, HStack, Text, VStack, Heading, StackDivider, Link, useBreakpointValue } from '@chakra-ui/react';
+import { ExternalLink } from 'react-feather';
 import { BeetsBox } from '~/components/box/BeetsBox';
 import { numberFormatUSDValue } from '~/lib/util/number-formats';
-import { tokenFormatAmount, tokenFormatAmountPrecise, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
+import { tokenFormatAmountPrecise, tokenGetAmountForAddress } from '~/lib/services/token/token-util';
 import TokenAvatar from '~/components/token/TokenAvatar';
 import { useGetTokens } from '~/lib/global/useToken';
 import { usePoolUserTokenBalancesInWallet } from '~/modules/pool/lib/usePoolUserTokenBalancesInWallet';
-import { useInvest } from '~/modules/pool/invest/lib/useInvest';
-import { usePoolGetMaxProportionalInvestmentAmount } from '~/modules/pool/invest/lib/usePoolGetMaxProportionalInvestmentAmount';
-import { CardRow } from '~/components/card/CardRow';
-import { PoolInvestStablePoolDescription } from '~/modules/pool/invest/components/PoolInvestStablePoolDescription';
-import { PoolInvestWeightedPoolDescription } from '~/modules/pool/invest/components/PoolInvestWeightedPoolDescription';
 import { usePool } from '~/modules/pool/lib/usePool';
 import Scales from '~/assets/icons/scales.svg';
 import BeetsThinking from '~/assets/icons/beetx-thinking.svg';
@@ -36,28 +14,25 @@ import BeetSmart from '~/assets/icons/beetx-smarts.svg';
 import Image from 'next/image';
 import { etherscanGetTokenUrl } from '~/lib/util/etherscan';
 import BeetsTooltip from '~/components/tooltip/BeetsTooltip';
+import { useReliquaryJoinGetProportionalInvestmentAmount } from '../lib/useReliquaryJoinGetProportionalInvestmentAmount';
+import { useReliquaryInvest } from '../lib/useReliquaryInvest';
 interface Props {
     onShowProportional(): void;
     onShowCustom(): void;
 }
 
 export function ReliquaryInvestTypeChoice({ onShowProportional, onShowCustom }: Props) {
-    const { pool, poolService, isStablePool } = usePool();
-    const { priceForAmount, formattedPrice } = useGetTokens();
+    const { pool } = usePool();
+    const { formattedPrice } = useGetTokens();
     const { userPoolTokenBalances, investableAmount } = usePoolUserTokenBalancesInWallet();
-    const { canInvestProportionally } = useInvest();
+    const { canInvestProportionally } = useReliquaryInvest();
     const isMobile = useBreakpointValue({ base: true, md: false });
-    const { data, isLoading } = usePoolGetMaxProportionalInvestmentAmount();
-    const proportionalSupported =
-        poolService.joinGetProportionalSuggestionForFixedAmount && pool.investConfig.proportionalEnabled;
+    const { totalValueProportionalAmounts } = useReliquaryJoinGetProportionalInvestmentAmount();
 
-    const _canInvestProportionally = (data?.maxAmount || 0) > 0 && canInvestProportionally && proportionalSupported;
+    const _canInvestProportionally = (totalValueProportionalAmounts || 0) > 0 && canInvestProportionally;
 
     const disabledProportionalInvestmentTooltip = useMemo(() => {
-        if (!proportionalSupported) {
-            return 'This pool does not support proportional investment.';
-        }
-        if ((data?.maxAmount || 0) <= 0) {
+        if ((totalValueProportionalAmounts || 0) <= 0) {
             return "You don't have the appropriate funds for a proportional investment. Refer below to the tokens you need to make a proportional investment.";
         }
         return 'This pool does not support proportional investment.';
@@ -72,21 +47,19 @@ export function ReliquaryInvestTypeChoice({ onShowProportional, onShowCustom }: 
                     <Heading size="sm">Choose your investment type</Heading>
                     <Box fontSize="base">
                         The max amount you can invest is shown for each option.
-                        {proportionalSupported && (
-                            <BeetsTooltip
-                                noImage
-                                label="When investing proportionally, you enter the Liquidity Pool in the specific ratios set by the pool. This helps to ensure you aren’t subject to the fees associated with price impact. Alternatively, customising your investment allows you to invest with your desired proportions. However, this action may shift the pool out of balance and subject you to price impact."
-                            >
-                                <HStack spacing="1" alignItems="center">
-                                    <Text color="beets.highlight" fontSize="sm">
-                                        What&apos;s the difference
-                                    </Text>
-                                    <Box _hover={{ transform: 'scale(1.2)' }}>
-                                        <Image src={BeetsThinking} width="24" height="24" alt="beets-balanced" />
-                                    </Box>
-                                </HStack>
-                            </BeetsTooltip>
-                        )}
+                        <BeetsTooltip
+                            noImage
+                            label="When investing proportionally, you enter the Liquidity Pool in the specific ratios set by the pool. This helps to ensure you aren’t subject to the fees associated with price impact. Alternatively, customising your investment allows you to invest with your desired proportions. However, this action may shift the pool out of balance and subject you to price impact."
+                        >
+                            <HStack spacing="1" alignItems="center">
+                                <Text color="beets.highlight" fontSize="sm">
+                                    What&apos;s the difference
+                                </Text>
+                                <Box _hover={{ transform: 'scale(1.2)' }}>
+                                    <Image src={BeetsThinking} width="24" height="24" alt="beets-balanced" />
+                                </Box>
+                            </HStack>
+                        </BeetsTooltip>
                     </Box>
                 </VStack>
 
@@ -97,7 +70,7 @@ export function ReliquaryInvestTypeChoice({ onShowProportional, onShowCustom }: 
                                 _hover={{ borderColor: 'beets.green' }}
                                 borderWidth={1}
                                 borderColor="beets.transparent"
-                                disabled={!_canInvestProportionally || !proportionalSupported}
+                                disabled={!_canInvestProportionally}
                                 height="140px"
                                 width="full"
                                 onClick={onShowProportional}
@@ -105,7 +78,9 @@ export function ReliquaryInvestTypeChoice({ onShowProportional, onShowCustom }: 
                                 <VStack spacing="1">
                                     <Image src={Scales} height="48" alt="beets-balanced" />
 
-                                    <Text fontSize="lg">{numberFormatUSDValue(data?.maxAmount || 0)}</Text>
+                                    <Text fontSize="lg">
+                                        {numberFormatUSDValue(totalValueProportionalAmounts || 0)}
+                                    </Text>
                                     <Text fontSize="sm">Proportional investment</Text>
                                     <Text fontSize="xs" color="beets.green">
                                         Recommended

--- a/modules/reliquary/invest/lib/useReliquaryJoinGetProportionalInvestmentAmount.ts
+++ b/modules/reliquary/invest/lib/useReliquaryJoinGetProportionalInvestmentAmount.ts
@@ -23,11 +23,11 @@ export function useReliquaryJoinGetProportionalInvestmentAmount() {
         async ({ queryKey }) => {
             const hasEth = !!userInvestTokenBalances.find((token) => isEth(token.address));
 
-            if (!poolService.joinGetProportionalSuggestion) {
+            if (!poolService.joinGetMaxProportionalForUserBalances) {
                 return {};
             }
 
-            const result = await poolService.joinGetProportionalSuggestion(userInvestTokenBalances);
+            const result = await poolService.joinGetMaxProportionalForUserBalances(userInvestTokenBalances);
 
             return {
                 tokenProportionalAmounts: Object.fromEntries(

--- a/modules/reliquary/invest/lib/useReliquaryJoinGetProportionalInvestmentAmount.ts
+++ b/modules/reliquary/invest/lib/useReliquaryJoinGetProportionalInvestmentAmount.ts
@@ -1,0 +1,75 @@
+import { useQuery } from 'react-query';
+import { sortBy, sumBy } from 'lodash';
+import { isEth, isWeth, replaceEthWithWeth, replaceWethWithEth } from '~/lib/services/token/token-util';
+import { useUserAccount } from '~/lib/user/useUserAccount';
+import { usePool } from '~/modules/pool/lib/usePool';
+import { useGetTokens } from '~/lib/global/useToken';
+import { useReliquaryInvest } from './useReliquaryInvest';
+
+export function useReliquaryJoinGetProportionalInvestmentAmount() {
+    const { poolService, pool } = usePool();
+    const { userInvestTokenBalances, selectedInvestTokens } = useReliquaryInvest();
+    const { userAddress } = useUserAccount();
+    const { priceForAmount } = useGetTokens();
+
+    const totalUserInvestTokenBalancesValue = sumBy(userInvestTokenBalances, priceForAmount);
+    const tokenWithSmallestValue = sortBy(
+        userInvestTokenBalances.map((balance) => {
+            const investOption = pool.investConfig.options.find((option) => {
+                const tokenOption = option.tokenOptions.find(
+                    (tokenOption) => tokenOption.address === replaceEthWithWeth(balance.address),
+                );
+
+                return !!tokenOption;
+            });
+
+            const poolToken = investOption ? pool.tokens[investOption.poolTokenIndex] : undefined;
+            //TODO: this is not exactly accurate as we assume here the invest token has a 1:priceRate ratio to the pool token, which is not the case
+            //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
+            const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
+
+            return {
+                ...balance,
+                //this has precision errors, but its only used for sorting, not any operations
+                normalizedAmount: poolToken?.weight
+                    ? //? scaledBalance / parseFloat(poolToken.balance) / parseFloat(poolToken.weight)
+                      priceForAmount({ address: balance.address, amount: scaledBalance.toString() }) -
+                      parseFloat(poolToken.weight) * totalUserInvestTokenBalancesValue
+                    : scaledBalance,
+            };
+        }),
+        'normalizedAmount',
+    )[0];
+
+    return useQuery(
+        [
+            {
+                key: 'joinGetProportionalInvestmentAmount',
+                userInvestTokenBalances,
+                tokenWithSmallestValue,
+                userAddress,
+            },
+        ],
+        async ({ queryKey }) => {
+            const hasEth = !!userInvestTokenBalances.find((token) => isEth(token.address));
+            const fixedAmount = {
+                ...tokenWithSmallestValue,
+                address: replaceEthWithWeth(tokenWithSmallestValue.address),
+            };
+
+            if (!poolService.joinGetProportionalSuggestionForFixedAmount) {
+                return {};
+            }
+
+            const result = await poolService.joinGetProportionalSuggestionForFixedAmount(
+                fixedAmount,
+                selectedInvestTokens.map((token) => replaceEthWithWeth(token.address)),
+            );
+
+            return Object.fromEntries(
+                result.map((item) => [hasEth ? replaceWethWithEth(item.address) : item.address, item.amount]),
+            );
+        },
+        { enabled: true, staleTime: 0, cacheTime: 0 },
+    );
+}

--- a/modules/reliquary/invest/lib/useReliquaryJoinGetProportionalInvestmentAmount.ts
+++ b/modules/reliquary/invest/lib/useReliquaryJoinGetProportionalInvestmentAmount.ts
@@ -28,13 +28,15 @@ export function useReliquaryJoinGetProportionalInvestmentAmount() {
             //TODO: as the invest token is often time nested deeper in linear pool of phantom stable
             const scaledBalance = parseFloat(balance.amount) / parseFloat(poolToken?.priceRate || '1');
 
+            const tokenValue = priceForAmount({ address: balance.address, amount: scaledBalance.toString() });
+            const weightedValue = parseFloat(poolToken?.weight || '1') * totalUserInvestTokenBalancesValue;
+
             return {
                 ...balance,
                 //this has precision errors, but its only used for sorting, not any operations
                 normalizedAmount: poolToken?.weight
                     ? //? scaledBalance / parseFloat(poolToken.balance) / parseFloat(poolToken.weight)
-                      priceForAmount({ address: balance.address, amount: scaledBalance.toString() }) -
-                      parseFloat(poolToken.weight) * totalUserInvestTokenBalancesValue
+                      (tokenValue - weightedValue) / weightedValue
                     : scaledBalance,
             };
         }),


### PR DESCRIPTION
Fixes #263 

Calculate the bptOut amounts for the (nested) tokens and use the smallest to determine the correct proportional amounts.


~~Reliquary was using the Pool version so that is also fixed here.~~ Need to update this.