### PR TITLE
filter out 'broken' pools

### DIFF
--- a/modules/linear-pools/LinearPoolList.tsx
+++ b/modules/linear-pools/LinearPoolList.tsx
@@ -13,7 +13,10 @@ export function LinearPoolList() {
     const [selectedPool, setSelectedPool] = useState<GqlPoolLinearFragment | null>(null);
     const { data, loading } = useGetLinearPoolsQuery({ pollInterval: 30000 });
     const { getToken } = useGetTokens();
-    const linearPools = orderBy(data?.pools || [], (pool) => parseFloat(pool.dynamicData.totalLiquidity), 'desc');
+    const linearPoolsFiltered = (data?.pools || []).filter((pool) =>
+        pool.tokens.find((token) => token.index === pool.mainIndex),
+    );
+    const linearPools = orderBy(linearPoolsFiltered, (pool) => parseFloat(pool.dynamicData.totalLiquidity), 'desc');
 
     return (
         <Box>


### PR DESCRIPTION
The pools below break the 'linear-pools' page on fantom:

- Beets Yearn Boosted Pool v2 (USDC) (balances: yvUSDC = 0, USDC = 1)
- DO NOT USE - Mock Linear Pool

This change will filter those pools out.