### PR TITLE
use correct decimals

### DIFF
--- a/lib/services/pool/lib/util.ts
+++ b/lib/services/pool/lib/util.ts
@@ -15,6 +15,7 @@ import {
     oldBnumScale,
     oldBnumScaleAmount,
     oldBnumToBnum,
+    oldBnumToHumanReadable,
     oldBnumZero,
 } from '~/lib/services/pool/lib/old-big-number';
 import OldBigNumber from 'bignumber.js';
@@ -555,9 +556,9 @@ export function poolGetNestedTokenEstimateForPoolTokenAmounts({
             //TODO: this is an estimation, but should be adequate assuming rates are up to date
             tokenAmountsOut.push({
                 address: mainToken.address,
-                amount: formatFixed(
-                    oldBnumScaleAmount(bptAmount.amount).times(linearPoolToken.priceRate).toFixed(0),
-                    18,
+                amount: oldBnumToHumanReadable(
+                    oldBnumScale(bptAmount.amount, mainToken.decimals).times(linearPoolToken.priceRate),
+                    mainToken.decimals,
                 ),
             });
         }


### PR DESCRIPTION
![proportional-invest-decimals-bug](https://user-images.githubusercontent.com/20125808/236816830-f21225ff-11c7-4208-9e8c-942e592bff85.gif)

The input updates the value using 18 decimals (hardcoded). When this is done with for example USDC the invest modal is killed  when clicking "Preview".
This is fixed by using the correct amount of decimals.

PS Yes there is also a max value bug.