### PR TITLE
reliquary max level fixes

### DIFF
--- a/lib/config/fantom.ts
+++ b/lib/config/fantom.ts
@@ -40,6 +40,7 @@ export const fantomNetworkConfig: NetworkConfig = {
             poolId: '0x9e4341acef4147196e99d648c5e43b3fc9d026780002000000000000000005ec',
             poolAddress: '0x9e4341acef4147196e99d648c5e43b3fc9d02678',
             farmId: 2,
+            maxLevel: 10,
         },
     },
     balancer: {

--- a/lib/config/network-config-type.ts
+++ b/lib/config/network-config-type.ts
@@ -55,6 +55,7 @@ export interface NetworkConfig {
             poolAddress: string;
             poolId: string;
             farmId: number;
+            maxLevel: number;
         };
     };
     balancer: {

--- a/lib/config/optimism.ts
+++ b/lib/config/optimism.ts
@@ -38,6 +38,7 @@ export const optimismNetworkConfig: NetworkConfig = {
             poolId: '',
             poolAddress: '',
             farmId: 0,
+            maxLevel: 0,
         },
     },
     balancer: {

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -27,6 +27,7 @@ export type ReliquaryDepositImpact = {
     oldLevelProgress: string;
     newLevelProgress: string;
     diffDate: Date;
+    staysMax: boolean;
 };
 
 export class ReliquaryService {
@@ -281,6 +282,8 @@ export class ReliquaryService {
         const diff = progressDiff + levelDiff * 604800;
         const diffDate = new Date((nowTimestamp + diff) * 1000);
 
+        const staysMax = levelOnUpdate === maxLevel && newLevel === maxLevel;
+
         return {
             oldMaturity: maturity,
             newMaturity,
@@ -289,6 +292,7 @@ export class ReliquaryService {
             oldLevelProgress,
             newLevelProgress,
             diffDate,
+            staysMax,
         };
     }
 }

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -278,7 +278,8 @@ export class ReliquaryService {
         const oldLevelProgressDiff = parseInt(maturityLevels[levelOnUpdateIndex].toString()) - maturity;
 
         const progressDiff = newLevelProgressDiff - oldLevelProgressDiff;
-        const levelDiff = levelOnUpdate - newLevel;
+        // you don't 'progress' through max level so we don't need to account for the time that would take
+        const levelDiff = levelOnUpdate === maxLevel ? 0 : levelOnUpdate - newLevel;
         const diff = progressDiff + levelDiff * 604800;
         const diffDate = new Date((nowTimestamp + diff) * 1000);
 

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -270,8 +270,12 @@ export class ReliquaryService {
         const newLevelProgress =
             newLevel > maturityLevels.length ? 'max level reached' : `${newMaturity}/${maturityLevels[newLevel + 1]}`;
 
-        const newLevelProgressDiff = parseInt(maturityLevels[newLevel + 1].toString()) - newMaturity;
-        const oldLevelProgressDiff = parseInt(maturityLevels[levelOnUpdate + 1].toString()) - maturity;
+        const maxLevel = 10; // zero based indexing, frontend will show '11'
+        const newLevelIndex = newLevel === maxLevel ? maxLevel : newLevel + 1;
+        const newLevelProgressDiff = parseInt(maturityLevels[newLevelIndex].toString()) - newMaturity;
+        const levelOnUpdateIndex = levelOnUpdate === maxLevel ? maxLevel : levelOnUpdate + 1;
+        const oldLevelProgressDiff = parseInt(maturityLevels[levelOnUpdateIndex].toString()) - maturity;
+
         const progressDiff = newLevelProgressDiff - oldLevelProgressDiff;
         const levelDiff = levelOnUpdate - newLevel;
         const diff = progressDiff + levelDiff * 604800;

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -271,11 +271,13 @@ export class ReliquaryService {
         const newLevelProgress =
             newLevel > maturityLevels.length ? 'max level reached' : `${newMaturity}/${maturityLevels[newLevel + 1]}`;
 
-        const maxLevel = 10; // zero based indexing, frontend will show '11'
-        const secondsToMaxLevel = parseInt(maturityLevels[maxLevel].toString()) - newMaturity;
+        const secondsToMaxLevel =
+            parseInt(maturityLevels[networkConfig.reliquary.fbeets.maxLevel].toString()) - newMaturity;
         const diffDate = new Date((nowTimestamp + secondsToMaxLevel) * 1000);
 
-        const staysMax = levelOnUpdate === maxLevel && newLevel === maxLevel;
+        const staysMax =
+            levelOnUpdate === networkConfig.reliquary.fbeets.maxLevel &&
+            newLevel === networkConfig.reliquary.fbeets.maxLevel;
 
         return {
             oldMaturity: maturity,

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -272,15 +272,8 @@ export class ReliquaryService {
             newLevel > maturityLevels.length ? 'max level reached' : `${newMaturity}/${maturityLevels[newLevel + 1]}`;
 
         const maxLevel = 10; // zero based indexing, frontend will show '11'
-        const newLevelIndex = newLevel === maxLevel ? maxLevel : newLevel + 1;
-        const newLevelProgressDiff = parseInt(maturityLevels[newLevelIndex].toString()) - newMaturity;
-        const levelOnUpdateIndex = levelOnUpdate === maxLevel ? maxLevel : levelOnUpdate + 1;
-        const oldLevelProgressDiff = parseInt(maturityLevels[levelOnUpdateIndex].toString()) - maturity;
-
-        const progressDiff = newLevelProgressDiff - oldLevelProgressDiff;
-        const levelDiff = levelOnUpdate - newLevel;
-        const diff = progressDiff + levelDiff * 604800;
-        const diffDate = new Date((nowTimestamp + diff) * 1000);
+        const secondsToMaxLevel = parseInt(maturityLevels[maxLevel].toString()) - newMaturity;
+        const diffDate = new Date((nowTimestamp + secondsToMaxLevel) * 1000);
 
         const staysMax = levelOnUpdate === maxLevel && newLevel === maxLevel;
 

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -278,8 +278,7 @@ export class ReliquaryService {
         const oldLevelProgressDiff = parseInt(maturityLevels[levelOnUpdateIndex].toString()) - maturity;
 
         const progressDiff = newLevelProgressDiff - oldLevelProgressDiff;
-        // you don't 'progress' through max level so we don't need to account for the time that would take
-        const levelDiff = levelOnUpdate === maxLevel ? 0 : levelOnUpdate - newLevel;
+        const levelDiff = levelOnUpdate - newLevel;
         const diff = progressDiff + levelDiff * 604800;
         const diffDate = new Date((nowTimestamp + diff) * 1000);
 

--- a/lib/services/staking/reliquary.service.ts
+++ b/lib/services/staking/reliquary.service.ts
@@ -26,7 +26,7 @@ export type ReliquaryDepositImpact = {
     newLevel: number;
     oldLevelProgress: string;
     newLevelProgress: string;
-    diffDate: Date;
+    depositImpactTimeInMilliseconds: number;
     staysMax: boolean;
 };
 
@@ -271,9 +271,7 @@ export class ReliquaryService {
         const newLevelProgress =
             newLevel > maturityLevels.length ? 'max level reached' : `${newMaturity}/${maturityLevels[newLevel + 1]}`;
 
-        const secondsToMaxLevel =
-            parseInt(maturityLevels[networkConfig.reliquary.fbeets.maxLevel].toString()) - newMaturity;
-        const diffDate = new Date((nowTimestamp + secondsToMaxLevel) * 1000);
+        const depositImpactTimeInMilliseconds = (maturity - newMaturity) * 1000;
 
         const staysMax =
             levelOnUpdate === networkConfig.reliquary.fbeets.maxLevel &&
@@ -286,7 +284,7 @@ export class ReliquaryService {
             newLevel,
             oldLevelProgress,
             newLevelProgress,
-            diffDate,
+            depositImpactTimeInMilliseconds,
             staysMax,
         };
     }

--- a/modules/reliquary/components/RelicSlideMainInfo.tsx
+++ b/modules/reliquary/components/RelicSlideMainInfo.tsx
@@ -74,25 +74,26 @@ export default function RelicSlideMainInfo({ isLoading, openInvestModal, openWit
                                         Level up progress
                                     </Text>
                                     <VStack alignItems="flex-start" w="full">
-                                        {!isMaxMaturity && (
-                                            <HStack spacing="1" color="beets.green">
-                                                <Text>Next level in</Text>
-                                                <Countdown date={levelUpDate} />
-                                            </HStack>
-                                        )}
-                                        {isMaxMaturity && (
+                                        {!isMaxMaturity ? (
+                                            <>
+                                                <HStack spacing="1" color="beets.green">
+                                                    <Text>Next level in</Text>
+                                                    <Countdown date={levelUpDate} />
+                                                </HStack>
+                                                <AnimatedProgress
+                                                    rounded="5"
+                                                    color="black"
+                                                    w="full"
+                                                    value={progressToNextLevel}
+                                                />
+                                            </>
+                                        ) : (
                                             <BeetsTooltip noImage label="You've achieved the max level, nice!">
                                                 <Box>
                                                     <Badge colorScheme="green">MAX LEVEL</Badge>
                                                 </Box>
                                             </BeetsTooltip>
                                         )}
-                                        <AnimatedProgress
-                                            rounded="5"
-                                            color="black"
-                                            w="full"
-                                            value={progressToNextLevel}
-                                        />
                                     </VStack>
                                 </VStack>
 

--- a/modules/reliquary/invest/components/ReliquaryInvestActions.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestActions.tsx
@@ -68,7 +68,7 @@ export function ReliquaryInvestActions({ onInvestComplete, onClose }: Props) {
             const investStep: TransactionStep = {
                 id: 'reliquary-invest',
                 type: 'other',
-                buttonText: `${createRelic ? 'CREATE and ' : ''}DEPOSIT`,
+                buttonText: `${createRelic ? 'Create and d' : 'D'}eposit`,
                 tooltipText: 'Create and/or deposit into your relic',
             };
 

--- a/modules/reliquary/invest/components/ReliquaryInvestDepositImpact.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestDepositImpact.tsx
@@ -34,7 +34,7 @@ export function ReliquaryInvestDepositImpact({ bptIn, totalInvestValue = 0, reli
                     `Investing ${numberFormatUSDValue(
                         totalInvestValue,
                     )} into this relic will affect its maturity. It will take an additional ${formatDistanceToNowStrict(
-                        depositImpact.diffDate,
+                        new Date(Date.now() + depositImpact.depositImpactTimeInMilliseconds),
                     )} to reach maximum maturity.`
                 ) : (
                     <Box w="full">

--- a/modules/reliquary/invest/components/ReliquaryInvestDepositImpact.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestDepositImpact.tsx
@@ -27,28 +27,31 @@ export function ReliquaryInvestDepositImpact({ bptIn, totalInvestValue = 0, reli
     }, [relicId]);
 
     return (
-        <Box w="full">
-            <Alert status="warning" mb="4">
-                <AlertIcon alignSelf="center" />
-                {!isFetching && depositImpact !== undefined ? (
-                    `Investing ${numberFormatUSDValue(
-                        totalInvestValue,
-                    )} into this relic will affect its maturity. It will take an additional ${formatDistanceToNowStrict(
-                        depositImpact.diffDate,
-                    )} to reach maximum maturity.`
-                ) : (
-                    <Box w="full">
-                        <SkeletonText
-                            my="2"
-                            startColor="beets.green"
-                            endColor="beets.highlight"
-                            noOfLines={3}
-                            spacing="4"
-                            skeletonHeight="2"
-                        />
-                    </Box>
-                )}
-            </Alert>
-        </Box>
+        depositImpact !== undefined &&
+        !depositImpact.staysMax && (
+            <Box w="full">
+                <Alert status="warning" mb="4">
+                    <AlertIcon alignSelf="center" />
+                    {!isFetching ? (
+                        `Investing ${numberFormatUSDValue(
+                            totalInvestValue,
+                        )} into this relic will affect its maturity. It will take an additional ${formatDistanceToNowStrict(
+                            depositImpact.diffDate,
+                        )} to reach maximum maturity.`
+                    ) : (
+                        <Box w="full">
+                            <SkeletonText
+                                my="2"
+                                startColor="beets.green"
+                                endColor="beets.highlight"
+                                noOfLines={3}
+                                spacing="4"
+                                skeletonHeight="2"
+                            />
+                        </Box>
+                    )}
+                </Alert>
+            </Box>
+        )
     );
 }

--- a/modules/reliquary/invest/components/ReliquaryInvestDepositImpact.tsx
+++ b/modules/reliquary/invest/components/ReliquaryInvestDepositImpact.tsx
@@ -26,32 +26,29 @@ export function ReliquaryInvestDepositImpact({ bptIn, totalInvestValue = 0, reli
         }
     }, [relicId]);
 
-    return (
-        depositImpact !== undefined &&
-        !depositImpact.staysMax && (
-            <Box w="full">
-                <Alert status="warning" mb="4">
-                    <AlertIcon alignSelf="center" />
-                    {!isFetching ? (
-                        `Investing ${numberFormatUSDValue(
-                            totalInvestValue,
-                        )} into this relic will affect its maturity. It will take an additional ${formatDistanceToNowStrict(
-                            depositImpact.diffDate,
-                        )} to reach maximum maturity.`
-                    ) : (
-                        <Box w="full">
-                            <SkeletonText
-                                my="2"
-                                startColor="beets.green"
-                                endColor="beets.highlight"
-                                noOfLines={3}
-                                spacing="4"
-                                skeletonHeight="2"
-                            />
-                        </Box>
-                    )}
-                </Alert>
-            </Box>
-        )
-    );
+    return depositImpact !== undefined && !depositImpact.staysMax ? (
+        <Box w="full">
+            <Alert status="warning" mb="4">
+                <AlertIcon alignSelf="center" />
+                {!isFetching ? (
+                    `Investing ${numberFormatUSDValue(
+                        totalInvestValue,
+                    )} into this relic will affect its maturity. It will take an additional ${formatDistanceToNowStrict(
+                        depositImpact.diffDate,
+                    )} to reach maximum maturity.`
+                ) : (
+                    <Box w="full">
+                        <SkeletonText
+                            my="2"
+                            startColor="beets.green"
+                            endColor="beets.highlight"
+                            noOfLines={3}
+                            spacing="4"
+                            skeletonHeight="2"
+                        />
+                    </Box>
+                )}
+            </Alert>
+        </Box>
+    ) : null;
 }


### PR DESCRIPTION
- fixes hanging of reliquary deposit impact message, this occurs when trying to deposit into a max level relic

![image](https://github.com/beethovenxfi/beets-frontend/assets/20125808/283fc289-19d7-4e58-b78d-2e1918f1cf81)

- hides the message when the deposit won't cause a drop in level (only when the relic is at max level!)
- fix the deposit (and create) text in line with the other button texts
- refactor the deposit impact (credits go to @franzns)
- hide progress bar on the dashboard for max level relics