### PR TITLE
Fix investing in pool with nested composable

### DIFF
--- a/lib/services/pool/lib/pool-composable-join.service.ts
+++ b/lib/services/pool/lib/pool-composable-join.service.ts
@@ -381,7 +381,7 @@ export class PoolComposableJoinService {
             if (token.__typename === 'GqlPoolTokenLinear' || token.__typename === 'GqlPoolTokenPhantomStable') {
                 //This token is a nested BPT, not a mainToken
                 //Replace the amount with the chained reference value
-                const index = assets.findIndex((asset) => asset.toLowerCase() === token.address) || -1;
+                const index = assets.findIndex((asset) => asset.toLowerCase() === token.address);
 
                 //if the return amount is 0, we dont pass on the chained reference
                 if (index === -1 || deltas[index] === '0') {


### PR DESCRIPTION
Fix BAL#208 BPT_OUT_MIN_AMOUNT error when trying to invest in a pool with a nested composable pool, for example this [one](https://beets.fi/pool/0x797d1e878342d59c93ce786f7a217c22ab12328c00020000000000000000074b).
See also my comment below.