### PR TITLE
add swap fee apr to selected relic apr

### DIFF
--- a/modules/reliquary/components/RelicSlideApr.tsx
+++ b/modules/reliquary/components/RelicSlideApr.tsx
@@ -56,6 +56,11 @@ export default function RelicSlideApr() {
     const { priceForAmount } = useGetTokens();
     const pendingRewardsUsdValue = sumBy(pendingRewards, priceForAmount);
 
+    const swapFeesItem = pool.dynamicData.apr.items.find((item) => item.title === 'Swap fees APR');
+    const swapFeesApr =
+        swapFeesItem?.apr && swapFeesItem.apr.__typename === 'GqlPoolAprTotal' ? swapFeesItem.apr.total : '0';
+    const totalSelectedRelicApr = (parseFloat(selectedRelicApr) + parseFloat(swapFeesApr)).toString();
+
     return (
         <>
             <Stack
@@ -84,7 +89,7 @@ export default function RelicSlideApr() {
                         Relic APR
                     </Text>
                     <HStack>
-                        <div className="apr-stripes">{numeral(selectedRelicApr).format('0.00%')}</div>
+                        <div className="apr-stripes">{numeral(totalSelectedRelicApr).format('0.00%')}</div>
                         <AprTooltip onlySparkles data={pool.dynamicData.apr} />
                     </HStack>
                     <HStack>


### PR DESCRIPTION
For a individual (selected) relic apr the swap fee apr should be added to it too.

![image](https://github.com/beethovenxfi/beets-frontend/assets/20125808/5fc2d842-decf-406c-9967-7ae37403f78c)
