### PR TITLE
Fix NaN in several places

### DIFF
--- a/lib/util/number-formats.ts
+++ b/lib/util/number-formats.ts
@@ -1,18 +1,17 @@
 import numeral from 'numeral';
 
-export function numberFormatUSDValue(value: string | number, addSign = true) {
+export function numberFormatUSDValue(value: string | number) {
     const valueNum = typeof value === 'string' ? parseFloat(value) : value;
-    const sign = addSign ? '$' : '';
 
     if (valueNum < 0.0001) {
-        return `${sign}0.00`;
+        return '$0.00';
     } else if (valueNum < 1) {
-        return numeral(valueNum).format(`${sign}0.00[00]`);
+        return numeral(valueNum).format('$0.00[00]');
     } else if (valueNum > 10000) {
-        return numeral(valueNum).format(`${sign}0,0`);
+        return numeral(valueNum).format('$0,0');
     }
 
-    return numeral(valueNum).format(`${sign}0,0.00`);
+    return numeral(valueNum).format('$0,0.00');
 }
 
 export function numberLimitInputToNumDecimals(value: string, decimals = 18) {

--- a/lib/util/number-formats.ts
+++ b/lib/util/number-formats.ts
@@ -1,17 +1,18 @@
 import numeral from 'numeral';
 
-export function numberFormatUSDValue(value: string | number) {
+export function numberFormatUSDValue(value: string | number, addSign = true) {
     const valueNum = typeof value === 'string' ? parseFloat(value) : value;
+    const sign = addSign ? '$' : '';
 
     if (valueNum < 0.0001) {
-        return '$0.00';
+        return `${sign}0.00`;
     } else if (valueNum < 1) {
-        return numeral(valueNum).format('$0.00[00]');
+        return numeral(valueNum).format(`${sign}0.00[00]`);
     } else if (valueNum > 10000) {
-        return numeral(valueNum).format('$0,0');
+        return numeral(valueNum).format(`${sign}0,0`);
     }
 
-    return numeral(valueNum).format('$0,0.00');
+    return numeral(valueNum).format(`${sign}0,0.00`);
 }
 
 export function numberLimitInputToNumDecimals(value: string, decimals = 18) {

--- a/modules/pool/detail/components/stats/PoolOverallStats.tsx
+++ b/modules/pool/detail/components/stats/PoolOverallStats.tsx
@@ -81,7 +81,7 @@ export default function PoolOverallStats() {
                     24h Volume
                 </Text>
                 <Text color="white" fontSize="1.75rem">
-                    {numeral(data.volume24h).format('$0,0.00a')}
+                    {numberFormatUSDValue(data.volume24h, false)}
                 </Text>
                 <PercentChangeBadge percentChange={volumePercentChange} />
             </VStack>
@@ -90,7 +90,7 @@ export default function PoolOverallStats() {
                     24h Fees
                 </Text>
                 <Text color="white" fontSize="1.75rem">
-                    {numeral(data.fees24h).format('$0,0.00a')}
+                    {numberFormatUSDValue(data.fees24h)}
                 </Text>
             </VStack>
             {(hasNonZeroRewards || beetsPerDay > 0) && (

--- a/modules/pool/detail/components/stats/PoolOverallStats.tsx
+++ b/modules/pool/detail/components/stats/PoolOverallStats.tsx
@@ -81,7 +81,7 @@ export default function PoolOverallStats() {
                     24h Volume
                 </Text>
                 <Text color="white" fontSize="1.75rem">
-                    {numberFormatUSDValue(data.volume24h, false)}
+                    {numberFormatUSDValue(data.volume24h)}
                 </Text>
                 <PercentChangeBadge percentChange={volumePercentChange} />
             </VStack>

--- a/modules/pool/detail/components/stats/PoolOverallStats.tsx
+++ b/modules/pool/detail/components/stats/PoolOverallStats.tsx
@@ -21,7 +21,8 @@ export default function PoolOverallStats() {
     const { data: blocksData } = useGetBlocksPerDayQuery({ fetchPolicy: 'cache-first' });
     const data = pool.dynamicData;
     const volumeYesterday = parseFloat(data.volume48h) - parseFloat(data.volume24h);
-    const volumePercentChange = (parseFloat(data.volume24h) - volumeYesterday) / volumeYesterday;
+    const volumePercentChange =
+        volumeYesterday !== 0 ? (parseFloat(data.volume24h) - volumeYesterday) / volumeYesterday : 0;
     const tvlPercentChange =
         (parseFloat(data.totalLiquidity) - parseFloat(data.totalLiquidity24hAgo)) /
         parseFloat(data.totalLiquidity24hAgo);

--- a/modules/pool/detail/components/transactions/PoolTransactionRow.tsx
+++ b/modules/pool/detail/components/transactions/PoolTransactionRow.tsx
@@ -1,11 +1,11 @@
 import { GqlPoolJoinExit, GqlPoolSwap } from '~/apollo/generated/graphql-codegen-generated';
 import { Box, Flex, Text, Link, Grid, GridItem, Stack, useBreakpointValue } from '@chakra-ui/react';
-import numeral from 'numeral';
 import { BoxProps, HStack } from '@chakra-ui/layout';
 import { ArrowDown, ArrowRight, ExternalLink, Minus, Plus, Zap } from 'react-feather';
 import { TokenAmountPill } from '~/components/token/TokenAmountPill';
 import { formatDistanceToNow } from 'date-fns';
 import { etherscanGetTxUrl } from '~/lib/util/etherscan';
+import { numberFormatUSDValue } from '~/lib/util/number-formats';
 
 export enum PoolTransactionType {
     Swap = 'SWAP',
@@ -133,10 +133,6 @@ function Pool(props: PoolTransaction) {
 }
 
 export default function PoolTransactionItem({ transaction, ...rest }: Props) {
-    const getFormattedValue = () => {
-        return numeral(transaction.transaction.valueUSD).format('$0,0.000');
-    };
-
     const flexAlign = { base: 'flex-start', lg: 'center' };
     const gridItemMb = { base: '4', lg: '0' };
     const justifyContent = { base: 'flex-start', lg: 'flex-end' };
@@ -171,7 +167,7 @@ export default function PoolTransactionItem({ transaction, ...rest }: Props) {
             <Flex align={flexAlign}>
                 <GridItem area="value" mb={gridItemMb}>
                     <MobileLabel text="Value" />
-                    <Text fontSize="md">{getFormattedValue()}</Text>
+                    <Text fontSize="md">{numberFormatUSDValue(transaction.transaction.valueUSD || '')}</Text>
                 </GridItem>
             </Flex>
             <Flex align={flexAlign} justify={justifyContent}>


### PR DESCRIPTION
Numbers like `2.60787852358763e-7` or `Infinity` are formatted as `NaN` by numeral.js.

Using `numberFormatUSDValue` instead fixes most issues. One issue was caused by 'divide by zero' so just return '0' in that case.

[Example](https://beets.fi/pool/0xff2753aaba51c9f84689b9bd0a21b3cf380a1cff00000000000000000000072e)
![image](https://github.com/beethovenxfi/beets-frontend/assets/20125808/88fb326a-582c-4d4d-94f1-d9f3bd39c0e6)
