### PR TITLE
don't disable token options on withdraw

### DIFF
--- a/components/inputs/BeetsTokenInputWithSlider.tsx
+++ b/components/inputs/BeetsTokenInputWithSlider.tsx
@@ -34,7 +34,7 @@ interface Props extends BoxProps {
     setInputAmount: (amount: AmountHumanReadable) => void;
     value?: string;
     proportionalAmount?: string;
-
+    isWithdraw?: boolean;
     setSelectedTokenOption: (address: string) => void;
 }
 
@@ -46,6 +46,7 @@ export function BeetsTokenInputWithSlider({
     value,
     proportionalAmount,
     setSelectedTokenOption,
+    isWithdraw,
     ...rest
 }: Props) {
     const { formattedPrice } = useGetTokens();
@@ -75,6 +76,7 @@ export function BeetsTokenInputWithSlider({
                             tokenOptions={tokenOptions}
                             selectedAddress={selectedTokenOption.address}
                             onOptionSelect={(address) => setSelectedTokenOption(address)}
+                            isWithdraw={isWithdraw}
                         />
                     </Box>
                 ) : (

--- a/components/token-select-inline/TokenSelectInline.tsx
+++ b/components/token-select-inline/TokenSelectInline.tsx
@@ -23,9 +23,10 @@ interface Props {
     selectedAddress: string;
     onOptionSelect: (address: string) => void;
     minimal?: boolean;
+    isWithdraw?: boolean;
 }
 
-export function TokenSelectInline({ tokenOptions, selectedAddress, onOptionSelect, minimal }: Props) {
+export function TokenSelectInline({ tokenOptions, selectedAddress, onOptionSelect, minimal, isWithdraw }: Props) {
     const theme = useTheme();
     const { getUserBalanceForToken } = usePoolUserTokenBalancesInWallet();
 
@@ -85,7 +86,7 @@ export function TokenSelectInline({ tokenOptions, selectedAddress, onOptionSelec
                                         <MenuItem
                                             key={option.address}
                                             display="flex"
-                                            isDisabled={option.hasZeroBalance}
+                                            isDisabled={!isWithdraw && option.hasZeroBalance}
                                             onClick={() => onOptionSelect(option.address)}
                                         >
                                             <HStack spacing="1.5" flex="1">

--- a/modules/pool/withdraw/components/PoolWithdrawSingleAsset.tsx
+++ b/modules/pool/withdraw/components/PoolWithdrawSingleAsset.tsx
@@ -77,6 +77,7 @@ export function PoolWithdrawSingleAsset({ onShowPreview, ...rest }: Props) {
                     }
                     value={singleAssetWithdraw.amount}
                     setSelectedTokenOption={setSingleAssetWithdraw}
+                    isWithdraw={true}
                 />
                 <PoolWithdrawSettings mt="6" />
                 <Collapse in={hasHighPriceImpact} animateOpacity>

--- a/modules/pool/withdraw/components/PoolWithdrawSingleAsset.tsx
+++ b/modules/pool/withdraw/components/PoolWithdrawSingleAsset.tsx
@@ -77,7 +77,7 @@ export function PoolWithdrawSingleAsset({ onShowPreview, ...rest }: Props) {
                     }
                     value={singleAssetWithdraw.amount}
                     setSelectedTokenOption={setSingleAssetWithdraw}
-                    isWithdraw={true}
+                    isWithdraw
                 />
                 <PoolWithdrawSettings mt="6" />
                 <Collapse in={hasHighPriceImpact} animateOpacity>

--- a/modules/reliquary/withdraw/components/ReliquaryWithdrawSingleAsset.tsx
+++ b/modules/reliquary/withdraw/components/ReliquaryWithdrawSingleAsset.tsx
@@ -66,6 +66,7 @@ export function ReliquaryWithdrawSingleAsset({ onShowPreview, ...rest }: Props) 
                 }
                 value={singleAssetWithdraw.amount}
                 setSelectedTokenOption={setSingleAssetWithdraw}
+                isWithdraw
             />
             <ReliquaryWithdrawSummary totalWithdrawValue={priceForAmount(singleAssetWithdraw)} mt="6" />
             <ReliquaryWithdrawSettings mt="6" />


### PR DESCRIPTION
(where applicable) a token option is disabled on invest when you don't have a balance for that token
when withdrawing having a balance or not does not matter so no token options should be disabled