### PR TITLE
temp workaround for users to claim all BAL rewards

### DIFF
--- a/lib/global/useStakingMintableRewards.ts
+++ b/lib/global/useStakingMintableRewards.ts
@@ -11,9 +11,15 @@ export default function useStakingMintableRewards(staking: GqlPoolStaking[]) {
     const { userAddress } = useUserAccount();
     const networkConfig = useNetworkConfig();
     const provider = useProvider();
-    const mintableGaugeAddresses = staking
-        .filter((staking) => staking.type === 'GAUGE' && staking.gauge?.version === 2)
-        .map((gauge) => gauge.address);
+
+    // temporary work around to claim all BAL from all gauges, also when user unstaked but forgot to claim them
+    // const mintableGaugeAddresses = staking
+    //     .filter((staking) => staking.type === 'GAUGE' && staking.gauge?.version === 2)
+    //     .map((gauge) => gauge.address);
+    const mintableGaugeAddresses = [
+        '0xf27d53f21d024643d50de50183932f17638229f6', // rocket fuel
+        '0x9f9f8d58496691d541c40dbc2b1b20f8c43e8d8c', // gyro eclp wsteth/weth
+    ];
 
     const {
         submit: submitClaimBAL,

--- a/lib/global/useStakingMintableRewards.ts
+++ b/lib/global/useStakingMintableRewards.ts
@@ -12,7 +12,8 @@ export default function useStakingMintableRewards(staking: GqlPoolStaking[]) {
     const networkConfig = useNetworkConfig();
     const provider = useProvider();
 
-    // temporary work around to claim all BAL from all gauges, also when user unstaked but forgot to claim them
+    // temporary work around to claim all BAL from all boosted gauges (hardcoded below), even when user unstaked but forgot to claim them
+    // this workaround will be removed when v6 of the batch relayer is released
     // const mintableGaugeAddresses = staking
     //     .filter((staking) => staking.type === 'GAUGE' && staking.gauge?.version === 2)
     //     .map((gauge) => gauge.address);

--- a/lib/global/useStakingPendingRewards.ts
+++ b/lib/global/useStakingPendingRewards.ts
@@ -13,16 +13,18 @@ import { useUserAccount } from '~/lib/user/useUserAccount';
 import { useRef } from 'react';
 import useStakingMintableRewards from './useStakingMintableRewards';
 import { useNetworkConfig } from './useNetworkConfig';
-import { uniqBy } from 'lodash';
+import { sum } from 'lodash';
 
 function calculateClaimableBAL(stakingItems: GqlPoolStaking[], claimableBALForGauges: Record<string, string>) {
     let claimableBAL = 0;
-    for (const stakingItem of stakingItems) {
-        if (stakingItem.type === 'GAUGE' && stakingItem.gauge?.version === 2) {
-            const claimableBALForGauge = claimableBALForGauges[stakingItem.gauge?.gaugeAddress || ''] || '0';
-            claimableBAL += parseFloat(claimableBALForGauge);
-        }
-    }
+    // temporary workaround to show all BAL rewards, even when user unstaked from a boosted gauge
+    // for (const stakingItem of stakingItems) {
+    //     if (stakingItem.type === 'GAUGE' && stakingItem.gauge?.version === 2) {
+    //         const claimableBALForGauge = claimableBALForGauges[stakingItem.gauge?.gaugeAddress || ''] || '0';
+    //         claimableBAL += parseFloat(claimableBALForGauge);
+    //     }
+    // }
+    claimableBAL = sum(Object.values(claimableBALForGauges));
     return claimableBAL;
 }
 
@@ -78,6 +80,8 @@ export function useStakingPendingRewards(stakingItems: GqlPoolStaking[], hookNam
                     id: 'claimable-bal',
                 },
             ];
+
+            console.log({ pendingRewards });
 
             return pendingRewards.filter((pendingReward) => parseFloat(pendingReward.amount) > 0);
         },

--- a/lib/global/useStakingPendingRewards.ts
+++ b/lib/global/useStakingPendingRewards.ts
@@ -81,8 +81,6 @@ export function useStakingPendingRewards(stakingItems: GqlPoolStaking[], hookNam
                 },
             ];
 
-            console.log({ pendingRewards });
-
             return pendingRewards.filter((pendingReward) => parseFloat(pendingReward.amount) > 0);
         },
         { enabled: !!userAddress && stakingItems.length > 0, refetchInterval: 15000 },

--- a/lib/global/useStakingPendingRewards.ts
+++ b/lib/global/useStakingPendingRewards.ts
@@ -18,6 +18,8 @@ import { sum } from 'lodash';
 function calculateClaimableBAL(stakingItems: GqlPoolStaking[], claimableBALForGauges: Record<string, string>) {
     let claimableBAL = 0;
     // temporary workaround to show all BAL rewards, even when user unstaked from a boosted gauge
+    // because the boosted gauge addresses are hardcoded in 'useStakingMintableRewards.ts' we can jum sum them here
+    // this workaround will be removed when v6 of the batch relayer is released
     // for (const stakingItem of stakingItems) {
     //     if (stakingItem.type === 'GAUGE' && stakingItem.gauge?.version === 2) {
     //         const claimableBALForGauge = claimableBALForGauges[stakingItem.gauge?.gaugeAddress || ''] || '0';


### PR DESCRIPTION
this is a temporary workaround to show/claim all BAL rewards from the navbar (even when the user unstaked from the gauge)

this can be removed again when the v6 relayer is released